### PR TITLE
Specialize data file location.

### DIFF
--- a/coin_data_miplib3.rb
+++ b/coin_data_miplib3.rb
@@ -8,7 +8,8 @@ class CoinDataMiplib3 < Formula
     system "./configure", "--disable-debug",
            "--disable-dependency-tracking",
            "--disable-silent-rules",
-           "--prefix=#{prefix}"
+           "--prefix=#{prefix}",
+           "--datadir=#{pkgshare}"
     system "make", "install"
   end
 end

--- a/coin_data_netlib.rb
+++ b/coin_data_netlib.rb
@@ -8,7 +8,8 @@ class CoinDataNetlib < Formula
     system "./configure", "--disable-debug",
            "--disable-dependency-tracking",
            "--disable-silent-rules",
-           "--prefix=#{prefix}"
+           "--prefix=#{prefix}",
+           "--datadir=#{pkgshare}"
     system "make", "install"
   end
 end

--- a/coin_data_sample.rb
+++ b/coin_data_sample.rb
@@ -8,7 +8,8 @@ class CoinDataSample < Formula
     system "./configure", "--disable-debug",
            "--disable-dependency-tracking",
            "--disable-silent-rules",
-           "--prefix=#{prefix}"
+           "--prefix=#{prefix}",
+           "--datadir=#{pkgshare}"
     system "make", "install"
   end
 end

--- a/coin_data_stochastic.rb
+++ b/coin_data_stochastic.rb
@@ -8,7 +8,8 @@ class CoinDataStochastic < Formula
     system "./configure", "--disable-debug",
            "--disable-dependency-tracking",
            "--disable-silent-rules",
-           "--prefix=#{prefix}"
+           "--prefix=#{prefix}",
+           "--datadir=#{pkgshare}"
     system "make", "install"
   end
 end


### PR DESCRIPTION
Homebrew doesn't manage common `share` locations across formulas.