### PR TITLE
Making CoinUtils dependent on glpk448

### DIFF
--- a/coinutils.rb
+++ b/coinutils.rb
@@ -4,6 +4,8 @@ class Coinutils < Formula
   url "http://www.coin-or.org/download/pkgsource/CoinUtils/CoinUtils-2.10.10.tgz"
   sha256 "bedace82a76d4644efabb3a0bce03d5f00933a8500dbff084a7b7791aeb91561"
 
+  option "with-glpk", "Build with support for reading AMPL/GMPL models" 
+
   depends_on :fortran
 
   depends_on "coin_data_sample"
@@ -13,10 +15,8 @@ class Coinutils < Formula
   depends_on "graphviz" => :build  # For documentation.
   depends_on "pkg-config" => :build
 
-  depends_on "homebrew/science/glpk448" => :optional
   depends_on "homebrew/science/openblas" => :optional
-
-  option "with-glpk", "Build with support for reading AMPL/GMPL models" 
+  depends_on "homebrew/science/glpk448" if build.with? "glpk"
 
   def install
     args = ["--disable-debug",

--- a/coinutils.rb
+++ b/coinutils.rb
@@ -13,8 +13,10 @@ class Coinutils < Formula
   depends_on "graphviz" => :build  # For documentation.
   depends_on "pkg-config" => :build
 
-  depends_on "homebrew/science/glpk" => :optional
+  depends_on "homebrew/science/glpk448" => :optional
   depends_on "homebrew/science/openblas" => :optional
+
+  option "with-glpk", "Build with support for reading AMPL/GMPL models" 
 
   def install
     args = ["--disable-debug",
@@ -28,8 +30,8 @@ class Coinutils < Formula
            ]
 
     if build.with? "glpk"
-      args << "--with-glpk-lib=-L#{Formula["glpk"].opt_lib} -lglpk"
-      args << "--with-glpk-incdir=#{Formula["glpk"].opt_include}"
+      args << "--with-glpk-lib=-L#{Formula["glpk448"].opt_lib} -lglpk"
+      args << "--with-glpk-incdir=#{Formula["glpk448"].opt_include}"
     end
 
     if build.with? "openblas"


### PR DESCRIPTION
I made `coinutils` dependent on `glpk448`, as we discussed [here](https://github.com/coin-or-tools/homebrew-coinor/pull/19#discussion-diff-44879793).  I had to add the option `--with-glpk` manually, since by default, it wanted to add `--with-glpk448`.