### PR TITLE
Modifying recipe to properly include option for GLPK support

### DIFF
--- a/clp.rb
+++ b/clp.rb
@@ -5,13 +5,15 @@ class Clp < Formula
   sha256 "05e8537c334d086b945389ea42a17ee70e4c192d1ff67ac6ab38817ace24b207"
   head "https://projects.coin-or.org/svn/Clp/trunk"
 
-  depends_on "homebrew/science/asl" => :optional
-  depends_on "homebrew/science/glpk" => :optional
-  depends_on "homebrew/science/openblas" => :optional
+  option "with-glpk", "Build with support for reading AMPL/GMPL models" 
 
   glpk_dep = (build.with? "glpk") ? ["with-glpk"] : []
   openblas_dep = (build.with? "openblas") ? ["with-openblas"] : []
+  suite_sparse_dep = (build.with? "suite-sparse") ? ["with-suite-sparse"] : []
 
+  depends_on "homebrew/science/openblas" => :optional
+  depends_on "homebrew/science/glpk448" => [:optional] + suite_sparse_dep
+  depends_on "homebrew/science/asl" => :optional
   depends_on "homebrew/science/mumps" => [:optional, "without-mpi"] + openblas_dep
   depends_on "homebrew/science/suite-sparse" => [:optional] + openblas_dep
 
@@ -29,6 +31,20 @@ class Clp < Formula
             "--with-netlib-datadir=#{Formula["coin_data_netlib"].opt_pkgshare}/coin/Data/Netlib",
             "--with-dot",
            ]
+
+    if build.with? "openblas"
+      openblaslib = "-L#{Formula["openblas"].opt_lib} -lopenblas"
+      openblasinc = "#{Formula["openblas"].opt_include}"
+      args << "--with-blas-lib=#{openblaslib}"
+      args << "--with-blas-incdir=#{openblasinc}"
+      args << "--with-lapack-lib=#{openblaslib}"
+      args << "--with-lapack-incdir=#{openblasinc}"
+    end
+
+    if build.with? "glpk"
+      args << "--with-glpk-lib=-L#{Formula["glpk448"].opt_lib} -lglpk"
+      args << "--with-glpk-incdir=#{Formula["glpk448"].opt_include}"
+    end
 
     if build.with? "asl"
       args << "--with-asl-incdir=#{Formula["asl"].opt_include}/asl"


### PR DESCRIPTION
This recipe doesn't currently work with the option `--with-glpk`, but I think the problem may need to be addressed elsewhere. The problem is two-fold. First, the `configure` of `clp` assumes that if the `glpk` package is present, then `suite-sparse` is also present, since the full `glpk` source distribution includes `suite-sparse` (as near as I can tell). However, the homebrew `glpk` package doesn't seem to install `suite-sparse`. I guess we need to say something like `--with-glpk => --with-suite-sparse`, even though `glpk` does not itself depend on `suite-sparse`. I couldn't quite see how to do that, although I'm sure there must be a way.

One workaround would be just to make `glpk448` depend on `suite-sparse`, since that package is mainly there for COIN projects anyway. Of course, another solution would be to make it so that Clp doesn't assume the presence of `suite-sparse` with `glpk`. I will think about whether that's a possible and easier solution to all this.

Unfortunately, there is a second issue and that is that it appears that `clp` depends on the version of `suite-sparse` that comes with `glpk448`, e.g., an older version. Just installing `suite-sparse` manually results in a compiler error:
```
Undefined symbols for architecture x86_64:
  "_amd_defaults", referenced from:
      ClpCholeskyUfl::order(ClpInterior*) in libClp.1.13.7.dylib-master.o
  "_amd_order", referenced from:
      ClpCholeskyUfl::order(ClpInterior*) in libClp.1.13.7.dylib-master.o
ld: symbol(s) not found for architecture x86_64
```
So for now, we might need to create a compatibility version of `suite-sparse`, too, but I'm not even sure what version that would be. Of course, we could also just punt and not allow building of `clp` with `glpk` for now. 