### PR TITLE
Fix osi dependency in clp.rb (Fixes #40)

### DIFF
--- a/clp.rb
+++ b/clp.rb
@@ -15,7 +15,7 @@ class Clp < Formula
   depends_on "homebrew/science/asl" => :optional
   depends_on "homebrew/science/mumps" => [:optional, "without-mpi"] + openblas_dep
 
-  ss_opts = openblas_dep
+  ss_opts = openblas_dep.clone
   ss_opts << :optional if build.without? "glpk"
   depends_on "homebrew/science/suite-sparse" => ss_opts
 


### PR DESCRIPTION
* The dependencies for suite-sparse were defined based on openblas
  dependencies, using

    ```ruby
    ss_opts = openblas_dep
    ss_opts << :optional if build.without? "glpk"
    ```

  In the second line, appending `:optional` to `ss_opts` modifies the
  original array, since `ss_opts` is just an alias to that array,
  and this causes the osi dependency to become optional below.

  Fixed by cloning openblas_dep

    ```ruby
    ss_opts = openblas_dep.clone
    ```