### PR TITLE
Update libraries and enable cbc parallel

### DIFF
--- a/cbc.rb
+++ b/cbc.rb
@@ -1,8 +1,8 @@
 class Cbc < Formula
   desc "Mixed integer linear programming solver"
   homepage "https://projects.coin-or.org/Cbc"
-  url "http://www.coin-or.org/download/pkgsource/Cbc/Cbc-2.9.6.tgz"
-  sha256 "b32c338465222594786de22943b7d124481f51a7642876809695e2ad1250f4f2"
+  url "https://www.coin-or.org/download/source/Cbc/Cbc-2.9.8.tgz"
+  sha256 "ff6860400a1390170f9cb19fab6f21c1997138d285b5f225be04c4642c9a7bea"
   head "https://projects.coin-or.org/svn/Cbc/trunk"
 
   depends_on "homebrew/science/asl" => :optional
@@ -29,6 +29,7 @@ class Cbc < Formula
             "--prefix=#{prefix}",
             "--datadir=#{pkgshare}",
             "--includedir=#{include}/cbc",
+            "--enable-cbc-parallel",
             "--with-sample-datadir=#{Formula["coin_data_sample"].opt_pkgshare}/coin/Data/Sample",
             "--with-netlib-datadir=#{Formula["coin_data_netlib"].opt_pkgshare}/coin/Data/Netlib",
             "--with-dot",

--- a/cgl.rb
+++ b/cgl.rb
@@ -1,8 +1,8 @@
 class Cgl < Formula
   desc "Cut-generation library"
   homepage "https://projects.coin-or.org/Cgl"
-  url "http://www.coin-or.org/download/pkgsource/Cgl/Cgl-0.59.6.tgz"
-  sha256 "7714a42526a98319bfa331d3d6a73a73c277abf23c3c59c25b602965b9d66d4c"
+  url "https://www.coin-or.org/download/pkgsource/Cgl/Cgl-0.59.9.tgz"
+  sha256 "d2d43e2a062f2c23328e6910a2606a7da49dec15d8fb4482f894293f6595e7b8"
   head "https://projects.coin-or.org/svn/Cgl/trunk"
 
   option "with-asl", "Build CLP with ASL support"

--- a/clp.rb
+++ b/clp.rb
@@ -1,8 +1,8 @@
 class Clp < Formula
   desc "Linear programming solver"
   homepage "https://projects.coin-or.org/Clp"
-  url "http://www.coin-or.org/download/pkgsource/Clp/Clp-1.16.7.tgz"
-  sha256 "05e8537c334d086b945389ea42a17ee70e4c192d1ff67ac6ab38817ace24b207"
+  url "https://www.coin-or.org/download/pkgsource/Clp/Clp-1.16.10.tgz"
+  sha256 "c642b2715c7f6997132e3251fdbfb77f662860b6588b1a5a6995453b2e062357"
   head "https://projects.coin-or.org/svn/Clp/trunk"
 
   option "with-glpk", "Build with support for reading AMPL/GMPL models"

--- a/coinutils.rb
+++ b/coinutils.rb
@@ -1,8 +1,8 @@
 class Coinutils < Formula
   desc "Utilities used by other Coin-OR projects"
   homepage "http://www.coin-or.org/projects/CoinUtils.xml"
-  url "http://www.coin-or.org/download/pkgsource/CoinUtils/CoinUtils-2.10.10.tgz"
-  sha256 "bedace82a76d4644efabb3a0bce03d5f00933a8500dbff084a7b7791aeb91561"
+  url "https://www.coin-or.org/download/pkgsource/CoinUtils/CoinUtils-2.10.13.tgz"
+  sha256 "e4ba7b7553d0a1f8136362e38e9e58a666f1e48770f72c5419db1f70a0dab0c9"
 
   option "with-glpk", "Build with support for reading AMPL/GMPL models" 
 

--- a/coinutils.rb
+++ b/coinutils.rb
@@ -1,6 +1,6 @@
 class Coinutils < Formula
   desc "Utilities used by other Coin-OR projects"
-  homepage "http://www.coin-or.org/projects/CoinUtils.xml"
+  homepage "https://projects.coin-or.org/CoinUtils"
   url "https://www.coin-or.org/download/pkgsource/CoinUtils/CoinUtils-2.10.13.tgz"
   sha256 "e4ba7b7553d0a1f8136362e38e9e58a666f1e48770f72c5419db1f70a0dab0c9"
 

--- a/osi.rb
+++ b/osi.rb
@@ -1,8 +1,8 @@
 class Osi < Formula
   desc "abstract class to a generic linear programming solver, and derived classes for specific solvers"
   homepage "https://projects.coin-or.org/Osi/"
-  url "http://www.coin-or.org/download/pkgsource/Osi/Osi-0.107.5.tgz"
-  sha256 "c578256853109e33a8ad8f1917ca8850a027d8a0987ef87166d34de1a256a57d"
+  url "https://www.coin-or.org/download/pkgsource/Osi/Osi-0.107.8.tgz"
+  sha256 "1522b428b5f6fef1d30aa518ccd01da0e4a62ebd4f919a6e6a235b1400fa66b8"
   head "https://projects.coin-or.org/svn/Osi/trunk"
 
   option "with-glpk", "Build with interface to GLPK and support for reading AMPL/GMPL models" 

--- a/symphony.rb
+++ b/symphony.rb
@@ -1,8 +1,8 @@
 class Symphony < Formula
   desc "Framework for solving mixed integer linear programs"
   homepage "https://projects.coin-or.org/SYMPHONY"
-  url "http://www.coin-or.org/download/pkgsource/SYMPHONY/SYMPHONY-5.6.14.tgz"
-  sha256 "666d1c72c4bb084b470c4f066b1694f7b3b11a479de15d9d1e9bfe1b53e3ae63"
+  url "https://www.coin-or.org/download/pkgsource/SYMPHONY/SYMPHONY-5.6.16.tgz"
+  sha256 "8578c2ff87b2c40f2f82bee3d145a6960c380a4ea850d760cad3a0b6e7c4e255"
   head "https://projects.coin-or.org/svn/SYMPHONY/trunk"
 
   option "without-openmp", "Disable openmp support"


### PR DESCRIPTION
This PR updates the libraries to the most recent version and also enables parallel support for CBC.
See #44 and #45 