### PR TITLE
updates related to homebrew/science

### DIFF
--- a/cbc.rb
+++ b/cbc.rb
@@ -1,27 +1,26 @@
 class Cbc < Formula
   desc "Mixed integer linear programming solver"
   homepage "https://projects.coin-or.org/Cbc"
-  url "http://www.coin-or.org/download/pkgsource/Cbc/Cbc-2.9.6.tgz"
+  url "https://www.coin-or.org/download/pkgsource/Cbc/Cbc-2.9.6.tgz"
   sha256 "b32c338465222594786de22943b7d124481f51a7642876809695e2ad1250f4f2"
   head "https://projects.coin-or.org/svn/Cbc/trunk"
 
-  depends_on "homebrew/science/asl" => :optional
-  depends_on "homebrew/science/glpk" => :optional
-  depends_on "homebrew/science/openblas" => :optional
+  depends_on "ampl-mp" => :optional
+  depends_on "gcc"
+  depends_on "glpk" => :optional
+  depends_on "dpo/openblas/mumps" => [:optional, "without-open-mpi"]
+  depends_on "openblas" => :optional
+  depends_on "pkg-config" => :build
+  depends_on "suite-sparse" => :optional
 
-  asl_dep = (build.with? "asl") ? ["with-asl"] : []
+  asl_dep = (build.with? "ampl-mp") ? ["with-ampl-mp"] : []
   glpk_dep = (build.with? "glpk") ? ["with-glpk"] : []
   openblas_dep = (build.with? "openblas") ? ["with-openblas"] : []
-
-  depends_on "homebrew/science/mumps" => [:optional, "without-mpi"] + openblas_dep
-  depends_on "homebrew/science/suite-sparse" => [:optional] + openblas_dep
-
   mumps_dep = (build.with? "mumps") ? ["with-mumps"] : []
   suite_sparse_dep = (build.with? "suite-sparse") ? ["with-suite-sparse"] : []
 
   depends_on "clp" => (asl_dep + glpk_dep + openblas_dep + mumps_dep + suite_sparse_dep)
   depends_on "cgl"
-  depends_on :fortran
 
   def install
     args = ["--disable-debug",
@@ -31,17 +30,16 @@ class Cbc < Formula
             "--includedir=#{include}/cbc",
             "--with-sample-datadir=#{Formula["coin_data_sample"].opt_pkgshare}/coin/Data/Sample",
             "--with-netlib-datadir=#{Formula["coin_data_netlib"].opt_pkgshare}/coin/Data/Netlib",
-            "--with-dot",
-           ]
+            "--with-dot"]
 
     if build.with? "glpk"
       args << "--with-glpk-lib=-L#{Formula["glpk"].opt_lib} -lglpk"
       args << "--with-glpk-incdir=#{Formula["glpk"].opt_include}"
     end
 
-    if build.with? "asl"
-      args << "--with-asl-incdir=#{Formula["asl"].opt_include}/asl"
-      args << "--with-asl-lib=-L#{Formula["asl"].opt_lib} -lasl"
+    if build.with? "ampl-mp"
+      args << "--with-asl-incdir=#{Formula["ampl-mp"].opt_include}/asl"
+      args << "--with-asl-lib=-L#{Formula["ampl-mp"].opt_lib} -lasl"
     end
 
     system "./configure", *args

--- a/cgl.rb
+++ b/cgl.rb
@@ -1,23 +1,24 @@
 class Cgl < Formula
   desc "Cut-generation library"
   homepage "https://projects.coin-or.org/Cgl"
-  url "http://www.coin-or.org/download/pkgsource/Cgl/Cgl-0.59.6.tgz"
+  url "https://www.coin-or.org/download/pkgsource/Cgl/Cgl-0.59.6.tgz"
   sha256 "7714a42526a98319bfa331d3d6a73a73c277abf23c3c59c25b602965b9d66d4c"
   head "https://projects.coin-or.org/svn/Cgl/trunk"
 
-  option "with-asl", "Build CLP with ASL support"
+  option "with-ampl-mp", "Build CLP with ASL support"
   option "with-glpk", "Build CLP with support for reading AMPL/GMPL models"
   option "with-mumps", "Build CLP with MUMPS support"
   option "with-openblas", "Build CLP with OpenBLAS support"
   option "with-suite-sparse", "Build CLP with SuiteSparse support"
 
-  asl_dep = (build.with? "asl") ? ["with-asl"] : []
+  asl_dep = (build.with? "ampl-mp") ? ["with-ampl-mp"] : []
   glpk_dep = (build.with? "glpk") ? ["with-glpk"] : []
   mumps_dep = (build.with? "mumps") ? ["with-mumps"] : []
   openblas_dep = (build.with? "openblas") ? ["with-openblas"] : []
   suitesparse_dep = (build.with? "suite-sparse") ? ["with-suite-sparse"] : []
 
   depends_on "clp" => (asl_dep + glpk_dep + mumps_dep + openblas_dep + suitesparse_dep)
+  depends_on "pkg-config" => :build
 
   def install
     args = ["--disable-debug",
@@ -26,8 +27,7 @@ class Cgl < Formula
             "--datadir=#{pkgshare}",
             "--includedir=#{include}/cgl",
             "--with-sample-datadir=#{Formula["coin_data_sample"].opt_pkgshare}/coin/Data/Sample",
-            "--with-dot",
-           ]
+            "--with-dot"]
 
     system "./configure", *args
 

--- a/clp.rb
+++ b/clp.rb
@@ -1,7 +1,7 @@
 class Clp < Formula
   desc "Linear programming solver"
   homepage "https://projects.coin-or.org/Clp"
-  url "http://www.coin-or.org/download/pkgsource/Clp/Clp-1.16.7.tgz"
+  url "https://www.coin-or.org/download/pkgsource/Clp/Clp-1.16.7.tgz"
   sha256 "05e8537c334d086b945389ea42a17ee70e4c192d1ff67ac6ab38817ace24b207"
   head "https://projects.coin-or.org/svn/Clp/trunk"
 
@@ -10,20 +10,19 @@ class Clp < Formula
   glpk_dep = (build.with? "glpk") ? ["with-glpk"] : []
   openblas_dep = (build.with? "openblas") ? ["with-openblas"] : []
 
-  depends_on "homebrew/science/openblas" => :optional
-  depends_on "homebrew/science/glpk448" if build.with? "glpk"
-  depends_on "homebrew/science/asl" => :optional
-  depends_on "homebrew/science/mumps" => [:optional, "without-mpi"] + openblas_dep
+  depends_on "ampl-mp" => :optional
+  depends_on "gcc"
+  depends_on "glpk448" if build.with? "glpk"
+  depends_on "openblas" => :optional
+  depends_on "suite-sparse" => :optional if build.without? "glpk"
 
-  ss_opts = openblas_dep.clone
-  ss_opts << :optional if build.without? "glpk"
-  depends_on "homebrew/science/suite-sparse" => ss_opts
+  depends_on "dpo/openblas/mumps" => [:optional, "without-open-mpi"]
 
   depends_on "coinutils"
   depends_on "osi" => (glpk_dep + openblas_dep)
+  depends_on "pkg-config" => :build
 
   depends_on "readline" => :recommended
-  depends_on :fortran
 
   def install
     args = ["--disable-debug",

--- a/coin_data_miplib3.rb
+++ b/coin_data_miplib3.rb
@@ -1,8 +1,8 @@
 class CoinDataMiplib3 < Formula
   desc "MIPLib models"
-  homepage "http://www.coin-or.org/download/pkgsource/Data"
-  url "http://www.coin-or.org/download/source/Data/miplib3-1.2.6.tgz"
-  sha256 "43449c8e9652af80a29044c31da51e9f600f28b211676ba8aa8b42bf8b31dee5"
+  homepage "https://www.coin-or.org/download/source/Data"
+  url "https://www.coin-or.org/download/source/Data/Data-miplib3-1.2.6.tgz"
+  sha256 "076d933c531ec65aa94945c7ba47c7bc0258d3844b7def5b3d62632c3fd961b8"
 
   def install
     system "./configure", "--disable-debug",

--- a/coin_data_netlib.rb
+++ b/coin_data_netlib.rb
@@ -1,8 +1,8 @@
 class CoinDataNetlib < Formula
   desc "Netlib LP models"
-  homepage "http://www.coin-or.org/download/pkgsource/Data"
-  url "http://www.coin-or.org/download/pkgsource/Data/Data-Netlib-1.2.6.tgz"
-  sha256 "dd687e5a35087ae0da825c5e24832b2ebaacc36a2ee73df084d4ef92e575e1ab"
+  homepage "https://www.coin-or.org/download/source/Data"
+  url "https://www.coin-or.org/download/source/Data/Data-Netlib-1.2.6.tgz"
+  sha256 "dd521ce48d8a7f5d7714d4ea2f095a97aa579ba22c6d5bda3c4c2e3706934c46"
 
   def install
     system "./configure", "--disable-debug",

--- a/coin_data_sample.rb
+++ b/coin_data_sample.rb
@@ -1,8 +1,8 @@
 class CoinDataSample < Formula
   desc "Sample models"
-  homepage "http://www.coin-or.org/download/pkgsource/Data"
-  url "http://www.coin-or.org/download/pkgsource/Data/Data-Sample-1.2.10.tgz"
-  sha256 "ec7de931a06126040910964b6ce89a3d0cf64132fdde187689cc13277e2c1985"
+  homepage "https://www.coin-or.org/download/source/Data"
+  url "https://www.coin-or.org/download/source/Data/Data-Sample-1.2.10.tgz"
+  sha256 "aaa25196f742a7905bab4e5021224a3b4000dd017b0f00bd05c890f7e6284f76"
 
   def install
     system "./configure", "--disable-debug",

--- a/coin_data_stochastic.rb
+++ b/coin_data_stochastic.rb
@@ -1,8 +1,8 @@
 class CoinDataStochastic < Formula
   desc "Stochastic models"
-  homepage "http://www.coin-or.org/download/pkgsource/Data"
-  url "http://www.coin-or.org/download/pkgsource/Data/Data-Stochastic-1.1.5.tgz"
-  sha256 "c6c3d1badd553684f15dc4a1db90fd641f937ad79f5b5f1c5100d323f5ebf15c"
+  homepage "https://www.coin-or.org/download/source/Data"
+  url "https://www.coin-or.org/download/source/Data/Data-Stochastic-1.1.5.tgz"
+  sha256 "6fdfa29b51e5d27ce243a902ae98bca9924390484262a3df8e986476d51f4692"
 
   def install
     system "./configure", "--disable-debug",

--- a/coinutils.rb
+++ b/coinutils.rb
@@ -1,22 +1,22 @@
 class Coinutils < Formula
   desc "Utilities used by other Coin-OR projects"
-  homepage "http://www.coin-or.org/projects/CoinUtils.xml"
-  url "http://www.coin-or.org/download/pkgsource/CoinUtils/CoinUtils-2.10.10.tgz"
+  homepage "https://projects.coin-or.org/CoinUtils"
+  url "https://www.coin-or.org/download/pkgsource/CoinUtils/CoinUtils-2.10.10.tgz"
   sha256 "bedace82a76d4644efabb3a0bce03d5f00933a8500dbff084a7b7791aeb91561"
 
-  option "with-glpk", "Build with support for reading AMPL/GMPL models" 
+  option "with-glpk", "Build with support for reading AMPL/GMPL models"
 
-  depends_on :fortran
+  depends_on "gcc"
 
   depends_on "coin_data_sample"
   depends_on "coin_data_netlib"
 
   depends_on "doxygen"
-  depends_on "graphviz" => :build  # For documentation.
+  depends_on "graphviz" => :build # For documentation.
   depends_on "pkg-config" => :build
 
-  depends_on "homebrew/science/openblas" => :optional
-  depends_on "homebrew/science/glpk448" if build.with? "glpk"
+  depends_on "openblas" => :optional
+  depends_on "glpk448" if build.with? "glpk"
 
   def install
     args = ["--disable-debug",
@@ -26,12 +26,11 @@ class Coinutils < Formula
             "--includedir=#{include}/coinutils",
             "--with-sample-datadir=#{Formula["coin_data_sample"].opt_pkgshare}/coin/Data/Sample",
             "--with-netlib-datadir=#{Formula["coin_data_netlib"].opt_pkgshare}/coin/Data/Netlib",
-            "--with-dot",
-           ]
+            "--with-dot"]
 
     if build.with? "openblas"
       openblaslib = "-L#{Formula["openblas"].opt_lib} -lopenblas"
-      openblasinc = "#{Formula["openblas"].opt_include}"
+      openblasinc = Formula["openblas"].opt_include.to_s
       args << "--with-blas-lib=#{openblaslib}"
       args << "--with-blas-incdir=#{openblasinc}"
       args << "--with-lapack-lib=#{openblaslib}"
@@ -46,7 +45,7 @@ class Coinutils < Formula
     system "./configure", *args
 
     system "make"
-    ENV.deparallelize  # make install fails in parallel.
+    ENV.deparallelize # make install fails in parallel.
     system "make", "test"
     system "make", "install"
   end

--- a/dylp.rb
+++ b/dylp.rb
@@ -1,9 +1,9 @@
 class Dylp < Formula
   desc "Dynamic simplex algorithm for linear programming"
   homepage "https://projects.coin-or.org/DyLP"
-  url "http://www.coin-or.org/download/pkgsource/DyLP/DyLP-1.10.2.tgz"
+  url "https://www.coin-or.org/download/pkgsource/DyLP/DyLP-1.10.2.tgz"
   sha256 "d17ff86c313aec7e6e00aa7abb3665446390096570cd141bf438afd65723db90"
-  head "https://projects.coin-or.org/svn/Dylp/trunk"
+  head "https://projects.coin-or.org/svn/DyLP/trunk"
 
   depends_on "osi"
 
@@ -15,8 +15,7 @@ class Dylp < Formula
             "--includedir=#{include}/dylp",
             "--with-sample-datadir=#{Formula["coin_data_sample"].opt_pkgshare}/coin/Data/Sample",
             "--with-netlib-datadir=#{Formula["coin_data_netlib"].opt_pkgshare}/coin/Data/Netlib",
-            "--with-dot",
-           ]
+            "--with-dot"]
 
     system "./configure", *args
 

--- a/glpk448.rb
+++ b/glpk448.rb
@@ -1,0 +1,69 @@
+class Glpk448 < Formula
+  desc "Library for Linear Programming"
+  homepage "https://www.gnu.org/software/glpk/"
+  url "https://ftp.gnu.org/gnu/glpk/glpk-4.48.tar.gz"
+  mirror "https://ftpmirror.gnu.org/glpk/glpk-4.48.tar.gz"
+  sha256 "abc2c8f895b20a91cdfcfc04367a0bc8677daf8b4ec3f3e86c5b71c79ac6adb1"
+
+  keg_only "this formula installs an older version of the GLPK libraries"
+
+  depends_on "gmp" => :recommended
+
+  patch :DATA
+
+  def install
+    args = %W[--disable-dependency-tracking --prefix=#{prefix}]
+    args << "--with-gmp" if build.with? "gmp"
+    system "./configure", *args
+    system "make"
+    system "make", "check"
+    system "make", "install"
+    include.install "src/amd/amd.h"
+    include.install "src/colamd/colamd.h"
+  end
+
+  test do
+    (testpath/"test.c").write <<-EOF.undent
+    #include "stdio.h"
+    #include "glpk.h"
+
+    int main(int argc, const char *argv[])
+    {
+        printf("%s", glp_version());
+        return 0;
+    }
+    EOF
+    system ENV.cc, "-I#{include}", "test.c", "-L#{lib}", "-lglpk", "-o", "test"
+    assert_equal `./test`, version.to_s
+  end
+end
+
+__END__
+diff --git a/src/Makefile.am b/src/Makefile.am
+index cec1f74..9e20042 100644
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -4,8 +4,7 @@ include_HEADERS = glpk.h
+
+ lib_LTLIBRARIES = libglpk.la
+
+-libglpk_la_LDFLAGS = -version-info 33:0:0 \
+--export-symbols-regex '^(glp_|_glp_lpx_).*'
++libglpk_la_LDFLAGS = -version-info 33:0:0
+
+ libglpk_la_SOURCES = \
+ glpapi01.c \
+diff --git a/src/Makefile.in b/src/Makefile.in
+index 6e61555..4d112dc 100644
+--- a/src/Makefile.in
++++ b/src/Makefile.in
+@@ -264,8 +264,7 @@ top_builddir = @top_builddir@
+ top_srcdir = @top_srcdir@
+ include_HEADERS = glpk.h
+ lib_LTLIBRARIES = libglpk.la
+-libglpk_la_LDFLAGS = -version-info 33:0:0 \
+--export-symbols-regex '^(glp_|_glp_lpx_).*'
++libglpk_la_LDFLAGS = -version-info 33:0:0
+
+ libglpk_la_SOURCES = \
+ glpapi01.c \

--- a/osi.rb
+++ b/osi.rb
@@ -1,19 +1,20 @@
 class Osi < Formula
-  desc "abstract class to a generic linear programming solver, and derived classes for specific solvers"
+  desc "Abstract class to generic LP solver, derived classes for specific solvers"
   homepage "https://projects.coin-or.org/Osi/"
-  url "http://www.coin-or.org/download/pkgsource/Osi/Osi-0.107.5.tgz"
+  url "https://www.coin-or.org/download/pkgsource/Osi/Osi-0.107.5.tgz"
   sha256 "c578256853109e33a8ad8f1917ca8850a027d8a0987ef87166d34de1a256a57d"
   head "https://projects.coin-or.org/svn/Osi/trunk"
 
-  option "with-glpk", "Build with interface to GLPK and support for reading AMPL/GMPL models" 
+  option "with-glpk", "Build with interface to GLPK and support for reading AMPL/GMPL models"
 
   glpk_dep = (build.with? "glpk") ? ["with-glpk"] : []
   openblas_dep = (build.with? "openblas") ? ["with-openblas"] : []
 
-  depends_on "homebrew/science/openblas" => :optional
-  depends_on "homebrew/science/glpk448" if build.with? "glpk"
+  depends_on "openblas" => :optional
+  depends_on "glpk448" if build.with? "glpk"
 
   depends_on "coinutils" => (glpk_dep + openblas_dep)
+  depends_on "pkg-config" => :build
 
   def install
     args = ["--disable-debug",
@@ -23,8 +24,7 @@ class Osi < Formula
             "--includedir=#{include}/osi",
             "--with-sample-datadir=#{Formula["coin_data_sample"].opt_pkgshare}/coin/Data/Sample",
             "--with-netlib-datadir=#{Formula["coin_data_netlib"].opt_pkgshare}/coin/Data/Netlib",
-            "--with-dot",
-           ]
+            "--with-dot"]
 
     if build.with? "glpk"
       args << "--with-glpk-lib=-L#{Formula["glpk448"].opt_lib} -lglpk"

--- a/symphony.rb
+++ b/symphony.rb
@@ -1,42 +1,42 @@
 class Symphony < Formula
   desc "Framework for solving mixed integer linear programs"
   homepage "https://projects.coin-or.org/SYMPHONY"
-  url "http://www.coin-or.org/download/pkgsource/SYMPHONY/SYMPHONY-5.6.14.tgz"
+  url "https://www.coin-or.org/download/pkgsource/SYMPHONY/SYMPHONY-5.6.14.tgz"
   sha256 "666d1c72c4bb084b470c4f066b1694f7b3b11a479de15d9d1e9bfe1b53e3ae63"
   head "https://projects.coin-or.org/svn/SYMPHONY/trunk"
 
   option "without-openmp", "Disable openmp support"
-  option "with-asl", "Build CLP with ASL support"
+  option "with-ampl-mp", "Build CLP with ASL support"
   option "with-glpk", "Build with support for reading AMPL/GMPL models"
   option "with-mumps", "Build CLP with MUMPS support"
   option "with-openblas", "Build CLP with OpenBLAS support"
   option "with-suite-sparse", "Build CLP with SuiteSparse support"
 
-  asl_dep = (build.with? "asl") ? ["with-asl"] : []
+  asl_dep = (build.with? "ampl-mp") ? ["with-ampl-mp"] : []
   glpk_dep = (build.with? "glpk") ? ["with-glpk"] : []
   mumps_dep = (build.with? "mumps") ? ["with-mumps"] : []
   openblas_dep = (build.with? "openblas") ? ["with-openblas"] : []
   suitesparse_dep = (build.with? "suite-sparse") ? ["with-suite-sparse"] : []
 
-  depends_on "homebrew/science/glpk448" if build.with? "glpk"
+  depends_on "gcc"
+  depends_on "glpk448" if build.with? "glpk"
+  depends_on "pkg-config" => :build
   depends_on "readline" => :recommended
-  depends_on "osi"
-  depends_on "clp" => (asl_dep + glpk_dep + mumps_dep + openblas_dep + suitesparse_dep)
+
   depends_on "cgl"
-  depends_on :fortran
+  depends_on "clp" => (asl_dep + glpk_dep + mumps_dep + openblas_dep + suitesparse_dep)
 
   def install
     args = ["--disable-debug",
             "--disable-dependency-tracking",
             "--prefix=#{prefix}",
             "--datadir=#{pkgshare}",
-            "--includedir=#{include}/cbc",
+            "--includedir=#{include}/symphony",
             "--with-sample-datadir=#{Formula["coin_data_sample"].opt_pkgshare}/coin/Data/Sample",
             "--with-netlib-datadir=#{Formula["coin_data_netlib"].opt_pkgshare}/coin/Data/Netlib",
             "--with-dot",
             "--enable-gnu-packages",
-            "--with-application",
-            ]
+            "--with-application"]
 
     if build.with? "readline"
       ENV.append "CXXFLAGS", "-I#{Formula["readline"].opt_include}"
@@ -60,7 +60,6 @@ class Symphony < Formula
 
     (pkgshare / "Datasets").install "Datasets/sample.mps"
     (pkgshare / "Datasets").install "Datasets/sample.mod", "Datasets/sample.dat" if build.with? "glpk"
-
   end
 
   test do

--- a/vol.rb
+++ b/vol.rb
@@ -1,7 +1,7 @@
 class Vol < Formula
   desc "Subgradient method that produces primal and dual solutions"
   homepage "https://projects.coin-or.org/Vol"
-  url "http://www.coin-or.org/download/pkgsource/Vol/Vol-1.5.2.tgz"
+  url "https://www.coin-or.org/download/pkgsource/Vol/Vol-1.5.2.tgz"
   sha256 "4b6f06159c58c79f1f40ad5bc5d4e069b4d0bbce3953f41f5c673493f2a09e54"
   head "https://projects.coin-or.org/svn/Vol/trunk"
 
@@ -15,8 +15,7 @@ class Vol < Formula
             "--datadir=#{pkgshare}",
             "--includedir=#{include}/vol",
             "--with-sample-datadir=#{Formula["coin_data_sample"].opt_pkgshare}/coin/Data/Sample",
-            "--with-dot",
-           ]
+            "--with-dot"]
 
     system "./configure", *args
 


### PR DESCRIPTION
homebrew/science is deprecated:
- mumps is now available from dpo/openblas
- glpk448 is now in this repository

also fix a number of audits