### PR TITLE
Formula dependency updates

### DIFF
--- a/cbc.rb
+++ b/cbc.rb
@@ -2,7 +2,7 @@ class Cbc < Formula
   desc "Mixed integer linear programming solver"
   homepage "https://github.com/coin-or/Cbc"
   url "https://github.com/coin-or/Cbc/archive/releases/2.10.5.tar.gz"
-  sha256 "6b823a3fab554774018ec636f21f73ac7edd439b995dc0897a187dd657b23f18"
+  sha256 ""
   head "https://github.com/coin-or/Cbc/tree/releases/2.10.5/Cbc"
   revision 2
 

--- a/cbc.rb
+++ b/cbc.rb
@@ -1,10 +1,10 @@
 class Cbc < Formula
   desc "Mixed integer linear programming solver"
-  homepage "https://projects.coin-or.org/Cbc"
-  url "https://www.coin-or.org/download/pkgsource/Cbc/Cbc-2.10.3.tgz"
+  homepage "https://github.com/coin-or/Cbc"
+  url "https://github.com/coin-or/Cbc/archive/releases/2.10.5.tar.gz"
   sha256 "6b823a3fab554774018ec636f21f73ac7edd439b995dc0897a187dd657b23f18"
-  head "https://projects.coin-or.org/svn/Cbc/trunk"
-  revision 1
+  head "https://github.com/coin-or/Cbc/tree/releases/2.10.5/Cbc"
+  revision 2
 
   option "with-glpk", "Build with support for reading AMPL/GMPL models"
   option "with-parallel", "Build with parallel mode enabled"

--- a/cbc.rb
+++ b/cbc.rb
@@ -1,18 +1,9 @@
 class Cbc < Formula
   desc "Mixed integer linear programming solver"
-<<<<<<< Updated upstream
   homepage "https://github.com/coin-or/Cbc"
   url "https://github.com/coin-or/Cbc/archive/releases/2.10.5.tar.gz"
-  sha256 " "
+  sha256 "cc44c1950ff4615e7791d7e03ea34318ca001d3cac6dc3f7f5ee392459ce6719"
   head "https://github.com/coin-or/Cbc/tree/releases/2.10.5/Cbc"
-  revision 2
-=======
-  homepage "https://github.com/coin-or/Cbc" # Updated homepage url reference to GitHub
-  url "https://github.com/coin-or/Cbc/archive/releases/2.10.5.tar.gz" # Updated url reference to GitHub, version updated to 2.10.5
-  sha256 "cc44c1950ff4615e7791d7e03ea34318ca001d3cac6dc3f7f5ee392459ce6719" # Updated sha256 checksum to match updated version
-  head "https://github.com/coin-or/Cbc/tree/releases/2.10.5/Cbc" # Updated url reference to GitHub, version updated to 2.10.5
-  revision 2 # Updated revision count
->>>>>>> Stashed changes
 
   option "with-glpk", "Build with support for reading AMPL/GMPL models"
   option "with-parallel", "Build with parallel mode enabled"

--- a/cbc.rb
+++ b/cbc.rb
@@ -2,7 +2,7 @@ class Cbc < Formula
   desc "Mixed integer linear programming solver"
   homepage "https://github.com/coin-or/Cbc"
   url "https://github.com/coin-or/Cbc/archive/releases/2.10.5.tar.gz"
-  sha256 ""
+  sha256 " "
   head "https://github.com/coin-or/Cbc/tree/releases/2.10.5/Cbc"
   revision 2
 

--- a/cbc.rb
+++ b/cbc.rb
@@ -1,10 +1,18 @@
 class Cbc < Formula
   desc "Mixed integer linear programming solver"
+<<<<<<< Updated upstream
   homepage "https://github.com/coin-or/Cbc"
   url "https://github.com/coin-or/Cbc/archive/releases/2.10.5.tar.gz"
   sha256 " "
   head "https://github.com/coin-or/Cbc/tree/releases/2.10.5/Cbc"
   revision 2
+=======
+  homepage "https://github.com/coin-or/Cbc" # Updated homepage url reference to GitHub
+  url "https://github.com/coin-or/Cbc/archive/releases/2.10.5.tar.gz" # Updated url reference to GitHub, version updated to 2.10.5
+  sha256 "cc44c1950ff4615e7791d7e03ea34318ca001d3cac6dc3f7f5ee392459ce6719" # Updated sha256 checksum to match updated version
+  head "https://github.com/coin-or/Cbc/tree/releases/2.10.5/Cbc" # Updated url reference to GitHub, version updated to 2.10.5
+  revision 2 # Updated revision count
+>>>>>>> Stashed changes
 
   option "with-glpk", "Build with support for reading AMPL/GMPL models"
   option "with-parallel", "Build with parallel mode enabled"

--- a/cgl.rb
+++ b/cgl.rb
@@ -1,10 +1,18 @@
 class Cgl < Formula
   desc "Cut-generation library"
+<<<<<<< Updated upstream
   homepage "https://github.com/coin-or/Cgl"
   url "https://github.com/coin-or/Cgl/archive/releases/0.60.3.tar.gz"
   sha256 ""
   head "https://github.com/coin-or/Cgl/tree/releases/0.60.3/Cgl"
   revision 1
+=======
+  homepage "https://github.com/coin-or/Cgl" # Updated homepage url reference to GitHub
+  url "https://github.com/coin-or/Cgl/archive/releases/0.60.3.tar.gz" # Updated url reference to GitHub, version updated to 0.60.3
+  sha256 "cfeeedd68feab7c0ce377eb9c7b61715120478f12c4dd0064b05ad640e20f3fb" # Updated sha256 checksum to match updated version
+  head "https://github.com/coin-or/Cgl/tree/releases/0.60.3/Cgl" # Updated url reference to GitHub, version updated to 0.60.3
+  revision 1  # Added revision count
+>>>>>>> Stashed changes
 
   option "with-ampl-mp", "Build CLP with ASL support"
   option "with-glpk", "Build CLP with support for reading AMPL/GMPL models"

--- a/cgl.rb
+++ b/cgl.rb
@@ -1,9 +1,10 @@
 class Cgl < Formula
   desc "Cut-generation library"
-  homepage "https://projects.coin-or.org/Cgl"
-  url "https://www.coin-or.org/download/pkgsource/Cgl/Cgl-0.60.2.tgz"
-  sha256 "44ce4c567a55d4e7550c31f9255e655e365108f03a2cd55db623c142a535a9e9"
-  head "https://projects.coin-or.org/svn/Cgl/trunk"
+  homepage "https://github.com/coin-or/Cgl"
+  url "https://github.com/coin-or/Cgl/archive/releases/0.60.3.tar.gz"
+  sha256 "6b823a3fab554774018ec636f21f73ac7edd439b995dc0897a187dd657b23f18"
+  head "https://github.com/coin-or/Cgl/tree/releases/0.60.3/Cgl"
+  revision 1
 
   option "with-ampl-mp", "Build CLP with ASL support"
   option "with-glpk", "Build CLP with support for reading AMPL/GMPL models"

--- a/cgl.rb
+++ b/cgl.rb
@@ -1,18 +1,9 @@
 class Cgl < Formula
   desc "Cut-generation library"
-<<<<<<< Updated upstream
-  homepage "https://github.com/coin-or/Cgl"
-  url "https://github.com/coin-or/Cgl/archive/releases/0.60.3.tar.gz"
-  sha256 ""
-  head "https://github.com/coin-or/Cgl/tree/releases/0.60.3/Cgl"
-  revision 1
-=======
-  homepage "https://github.com/coin-or/Cgl" # Updated homepage url reference to GitHub
-  url "https://github.com/coin-or/Cgl/archive/releases/0.60.3.tar.gz" # Updated url reference to GitHub, version updated to 0.60.3
-  sha256 "cfeeedd68feab7c0ce377eb9c7b61715120478f12c4dd0064b05ad640e20f3fb" # Updated sha256 checksum to match updated version
-  head "https://github.com/coin-or/Cgl/tree/releases/0.60.3/Cgl" # Updated url reference to GitHub, version updated to 0.60.3
-  revision 1  # Added revision count
->>>>>>> Stashed changes
+  homepage "https://github.com/coin-or/Cgl" 
+  url "https://github.com/coin-or/Cgl/archive/releases/0.60.3.tar.gz" 
+  sha256 "cfeeedd68feab7c0ce377eb9c7b61715120478f12c4dd0064b05ad640e20f3fb"
+  head "https://github.com/coin-or/Cgl/tree/releases/0.60.3/Cgl" 
 
   option "with-ampl-mp", "Build CLP with ASL support"
   option "with-glpk", "Build CLP with support for reading AMPL/GMPL models"

--- a/cgl.rb
+++ b/cgl.rb
@@ -2,7 +2,7 @@ class Cgl < Formula
   desc "Cut-generation library"
   homepage "https://github.com/coin-or/Cgl"
   url "https://github.com/coin-or/Cgl/archive/releases/0.60.3.tar.gz"
-  sha256 "6b823a3fab554774018ec636f21f73ac7edd439b995dc0897a187dd657b23f18"
+  sha256 ""
   head "https://github.com/coin-or/Cgl/tree/releases/0.60.3/Cgl"
   revision 1
 

--- a/clp.rb
+++ b/clp.rb
@@ -1,9 +1,10 @@
 class Clp < Formula
   desc "Linear programming solver"
-  homepage "https://projects.coin-or.org/Clp"
-  url "https://www.coin-or.org/download/pkgsource/Clp/Clp-1.17.3.tgz"
-  sha256 "c68fd7ed1cba58993d21ba61298366b2d26c6420ba4dbd470d38c3f617316e93"
-  head "https://projects.coin-or.org/svn/Clp/trunk"
+  homepage "https://github.com/coin-or/Clp"
+  url "https://github.com/coin-or/Clp/archive/releases/1.17.6.tar.gz"
+  sha256 ""
+  head "https://github.com/coin-or/Clp/tree/releases/1.17.6/Clp"
+  revision 1
 
   option "with-glpk", "Build with support for reading AMPL/GMPL models"
 

--- a/clp.rb
+++ b/clp.rb
@@ -1,18 +1,9 @@
 class Clp < Formula
   desc "Linear programming solver"
-<<<<<<< Updated upstream
   homepage "https://github.com/coin-or/Clp"
   url "https://github.com/coin-or/Clp/archive/releases/1.17.6.tar.gz"
-  sha256 ""
+  sha256 "afff465b1620cfcbb7b7c17b5d331d412039650ff471c4160c7eb24ae01284c9"
   head "https://github.com/coin-or/Clp/tree/releases/1.17.6/Clp"
-  revision 1
-=======
-  homepage "https://github.com/coin-or/Clp" # Updated homepage url reference to GitHub
-  url "https://github.com/coin-or/Clp/archive/releases/1.17.6.tar.gz" # Updated url reference to GitHub, version updated to 1.17.6
-  sha256 "afff465b1620cfcbb7b7c17b5d331d412039650ff471c4160c7eb24ae01284c9" # Updated sha256 checksum to match updated version
-  head "https://github.com/coin-or/Clp/tree/releases/1.17.6/Clp" # Updated head url reference to GitHub, version updated to 1.17.6
-  revision 1  # Added revision count
->>>>>>> Stashed changes
 
   option "with-glpk", "Build with support for reading AMPL/GMPL models"
 

--- a/clp.rb
+++ b/clp.rb
@@ -1,10 +1,18 @@
 class Clp < Formula
   desc "Linear programming solver"
+<<<<<<< Updated upstream
   homepage "https://github.com/coin-or/Clp"
   url "https://github.com/coin-or/Clp/archive/releases/1.17.6.tar.gz"
   sha256 ""
   head "https://github.com/coin-or/Clp/tree/releases/1.17.6/Clp"
   revision 1
+=======
+  homepage "https://github.com/coin-or/Clp" # Updated homepage url reference to GitHub
+  url "https://github.com/coin-or/Clp/archive/releases/1.17.6.tar.gz" # Updated url reference to GitHub, version updated to 1.17.6
+  sha256 "afff465b1620cfcbb7b7c17b5d331d412039650ff471c4160c7eb24ae01284c9" # Updated sha256 checksum to match updated version
+  head "https://github.com/coin-or/Clp/tree/releases/1.17.6/Clp" # Updated head url reference to GitHub, version updated to 1.17.6
+  revision 1  # Added revision count
+>>>>>>> Stashed changes
 
   option "with-glpk", "Build with support for reading AMPL/GMPL models"
 

--- a/coin_data_miplib3.rb
+++ b/coin_data_miplib3.rb
@@ -1,16 +1,9 @@
 class CoinDataMiplib3 < Formula
   desc "MIPLib models"
-<<<<<<< Updated upstream
-  homepage "https://www.coin-or.org/download/source/Data"
-  url "https://www.coin-or.org/download/source/Data/Data-miplib3-1.2.8.tgz"
-  sha256 ""
-=======
-  homepage "https://github.com/coin-or-tools/Data-miplib3" # Updated homepage url reference to GitHub
-  url "https://github.com/coin-or-tools/Data-miplib3/archive/releases/1.2.8.tar.gz" # Updated url reference to GitHub, version updated to 1.2.8
-  sha256 "72f5255e3078406e3c6f2fee01ead0cd7a4b182c35ffa2c5d4ebd230914c0fe3" # Updated sha256 checksum to match updated version
-  head "https://github.com/coin-or-tools/Data-Netlib/tree/releases/1.2.8" # Added head and made url reference to GitHub for version 1.2.8
-  revision 1  # Added revision count
->>>>>>> Stashed changes
+  homepage "https://github.com/coin-or-tools/Data-miplib3" 
+  url "https://github.com/coin-or-tools/Data-miplib3/archive/releases/1.2.8.tar.gz" 
+  sha256 "72f5255e3078406e3c6f2fee01ead0cd7a4b182c35ffa2c5d4ebd230914c0fe3"
+  head "https://github.com/coin-or-tools/Data-Netlib/tree/releases/1.2.8"
 
   def install
     system "./configure", "--disable-debug",

--- a/coin_data_miplib3.rb
+++ b/coin_data_miplib3.rb
@@ -1,8 +1,16 @@
 class CoinDataMiplib3 < Formula
   desc "MIPLib models"
+<<<<<<< Updated upstream
   homepage "https://www.coin-or.org/download/source/Data"
   url "https://www.coin-or.org/download/source/Data/Data-miplib3-1.2.8.tgz"
   sha256 ""
+=======
+  homepage "https://github.com/coin-or-tools/Data-miplib3" # Updated homepage url reference to GitHub
+  url "https://github.com/coin-or-tools/Data-miplib3/archive/releases/1.2.8.tar.gz" # Updated url reference to GitHub, version updated to 1.2.8
+  sha256 "72f5255e3078406e3c6f2fee01ead0cd7a4b182c35ffa2c5d4ebd230914c0fe3" # Updated sha256 checksum to match updated version
+  head "https://github.com/coin-or-tools/Data-Netlib/tree/releases/1.2.8" # Added head and made url reference to GitHub for version 1.2.8
+  revision 1  # Added revision count
+>>>>>>> Stashed changes
 
   def install
     system "./configure", "--disable-debug",

--- a/coin_data_miplib3.rb
+++ b/coin_data_miplib3.rb
@@ -1,8 +1,8 @@
 class CoinDataMiplib3 < Formula
   desc "MIPLib models"
   homepage "https://www.coin-or.org/download/source/Data"
-  url "https://www.coin-or.org/download/source/Data/Data-miplib3-1.2.7.tgz"
-  sha256 "7a6b15435e77e6758d605d0654f0fd2aeeec2d34061b0e95e71f698a047cbb4b"
+  url "https://www.coin-or.org/download/source/Data/Data-miplib3-1.2.8.tgz"
+  sha256 ""
 
   def install
     system "./configure", "--disable-debug",

--- a/coin_data_miplib3.rb
+++ b/coin_data_miplib3.rb
@@ -2,7 +2,7 @@ class CoinDataMiplib3 < Formula
   desc "MIPLib models"
   homepage "https://www.coin-or.org/download/source/Data"
   url "https://www.coin-or.org/download/source/Data/Data-miplib3-1.2.8.tgz"
-  sha256 " "
+  sha256 ""
 
   def install
     system "./configure", "--disable-debug",

--- a/coin_data_miplib3.rb
+++ b/coin_data_miplib3.rb
@@ -2,7 +2,7 @@ class CoinDataMiplib3 < Formula
   desc "MIPLib models"
   homepage "https://www.coin-or.org/download/source/Data"
   url "https://www.coin-or.org/download/source/Data/Data-miplib3-1.2.8.tgz"
-  sha256 ""
+  sha256 " "
 
   def install
     system "./configure", "--disable-debug",

--- a/coin_data_netlib.rb
+++ b/coin_data_netlib.rb
@@ -1,8 +1,8 @@
 class CoinDataNetlib < Formula
   desc "Netlib LP models"
   homepage "https://www.coin-or.org/download/source/Data"
-  url "https://www.coin-or.org/download/source/Data/Data-Netlib-1.2.8.tgz"
-  sha256 "f6358d756a1d0ae2ac159a422ceb661f080bf527f7b5a3e30320839beb8de3e4"
+  url "https://www.coin-or.org/download/source/Data/Data-Netlib-1.2.9.tgz"
+  sha256 ""
 
   def install
     system "./configure", "--disable-debug",

--- a/coin_data_netlib.rb
+++ b/coin_data_netlib.rb
@@ -1,16 +1,9 @@
 class CoinDataNetlib < Formula
   desc "Netlib LP models"
-<<<<<<< Updated upstream
-  homepage "https://www.coin-or.org/download/source/Data"
-  url "https://www.coin-or.org/download/source/Data/Data-Netlib-1.2.9.tgz"
-  sha256 ""
-=======
-  homepage "https://github.com/coin-or-tools/Data-Netlib" # Updated homepage url reference to GitHub
-  url "https://github.com/coin-or-tools/Data-Netlib/archive/releases/1.2.9.tar.gz" # Updated url reference to GitHub, version updated to 1.2.9
-  sha256 "cfc9f4ca02db25458cce66f2b9128daf623cb9204ef41e980fc42dedeb0f76d0" # Updated sha256 checksum to match updated version
-  head "https://github.com/coin-or-tools/Data-Netlib/tree/releases/1.2.9" # Added head and made url reference to GitHub for version 1.2.9
-  revision 1  # Added revision count
->>>>>>> Stashed changes
+  homepage "https://github.com/coin-or-tools/Data-Netlib"
+  url "https://github.com/coin-or-tools/Data-Netlib/archive/releases/1.2.9.tar.gz"
+  sha256 "cfc9f4ca02db25458cce66f2b9128daf623cb9204ef41e980fc42dedeb0f76d0"
+  head "https://github.com/coin-or-tools/Data-Netlib/tree/releases/1.2.9"
 
   def install
     system "./configure", "--disable-debug",

--- a/coin_data_netlib.rb
+++ b/coin_data_netlib.rb
@@ -1,8 +1,16 @@
 class CoinDataNetlib < Formula
   desc "Netlib LP models"
+<<<<<<< Updated upstream
   homepage "https://www.coin-or.org/download/source/Data"
   url "https://www.coin-or.org/download/source/Data/Data-Netlib-1.2.9.tgz"
   sha256 ""
+=======
+  homepage "https://github.com/coin-or-tools/Data-Netlib" # Updated homepage url reference to GitHub
+  url "https://github.com/coin-or-tools/Data-Netlib/archive/releases/1.2.9.tar.gz" # Updated url reference to GitHub, version updated to 1.2.9
+  sha256 "cfc9f4ca02db25458cce66f2b9128daf623cb9204ef41e980fc42dedeb0f76d0" # Updated sha256 checksum to match updated version
+  head "https://github.com/coin-or-tools/Data-Netlib/tree/releases/1.2.9" # Added head and made url reference to GitHub for version 1.2.9
+  revision 1  # Added revision count
+>>>>>>> Stashed changes
 
   def install
     system "./configure", "--disable-debug",

--- a/coin_data_sample.rb
+++ b/coin_data_sample.rb
@@ -1,8 +1,16 @@
 class CoinDataSample < Formula
   desc "Sample models"
+<<<<<<< Updated upstream
   homepage "https://www.coin-or.org/download/source/Data"
   url "https://www.coin-or.org/download/source/Data/Data-Sample-1.2.12.tgz"
   sha256 ""
+=======
+  homepage "https://github.com/coin-or-tools/Data-Sample" # Updated homepage url reference to GitHub
+  url "https://github.com/coin-or-tools/Data-Sample/archive/releases/1.2.12.tar.gz" # Updated url reference to GitHub, version updated to 1.2.12
+  sha256 "e9e67c04adfbd85523890b346326b106075df615e922c229277e138dbcb77e64" # Updated sha256 checksum to match updated version
+  head "https://github.com/coin-or-tools/Data-Sample/tree/releases/1.2.12" # Added head and made url reference to GitHub for version 1.2.12
+  revision 1  # Added revision count
+>>>>>>> Stashed changes
 
   def install
     system "./configure", "--disable-debug",

--- a/coin_data_sample.rb
+++ b/coin_data_sample.rb
@@ -1,8 +1,8 @@
 class CoinDataSample < Formula
   desc "Sample models"
   homepage "https://www.coin-or.org/download/source/Data"
-  url "https://www.coin-or.org/download/source/Data/Data-Sample-1.2.11.tgz"
-  sha256 "7d201dc37098dd1f7d68c24d71ca8083eaaa344ec44bd18799ac6245363f8467"
+  url "https://www.coin-or.org/download/source/Data/Data-Sample-1.2.12.tgz"
+  sha256 ""
 
   def install
     system "./configure", "--disable-debug",

--- a/coin_data_sample.rb
+++ b/coin_data_sample.rb
@@ -1,16 +1,9 @@
 class CoinDataSample < Formula
   desc "Sample models"
-<<<<<<< Updated upstream
-  homepage "https://www.coin-or.org/download/source/Data"
-  url "https://www.coin-or.org/download/source/Data/Data-Sample-1.2.12.tgz"
-  sha256 ""
-=======
-  homepage "https://github.com/coin-or-tools/Data-Sample" # Updated homepage url reference to GitHub
-  url "https://github.com/coin-or-tools/Data-Sample/archive/releases/1.2.12.tar.gz" # Updated url reference to GitHub, version updated to 1.2.12
-  sha256 "e9e67c04adfbd85523890b346326b106075df615e922c229277e138dbcb77e64" # Updated sha256 checksum to match updated version
-  head "https://github.com/coin-or-tools/Data-Sample/tree/releases/1.2.12" # Added head and made url reference to GitHub for version 1.2.12
-  revision 1  # Added revision count
->>>>>>> Stashed changes
+  homepage "https://github.com/coin-or-tools/Data-Sample"
+  url "https://github.com/coin-or-tools/Data-Sample/archive/releases/1.2.12.tar.gz"
+  sha256 "e9e67c04adfbd85523890b346326b106075df615e922c229277e138dbcb77e64" 
+  head "https://github.com/coin-or-tools/Data-Sample/tree/releases/1.2.12" 
 
   def install
     system "./configure", "--disable-debug",

--- a/coin_data_stochastic.rb
+++ b/coin_data_stochastic.rb
@@ -1,8 +1,8 @@
 class CoinDataStochastic < Formula
   desc "Stochastic models"
   homepage "https://www.coin-or.org/download/source/Data"
-  url "https://www.coin-or.org/download/source/Data/Data-Stochastic-1.1.6.tgz"
-  sha256 "2e2df9cd16bb8d07739cc5b14f0b52a6e697cd181e5e3c793cff83804491c255"
+  url "https://www.coin-or.org/download/source/Data/Data-Stochastic-1.1.7.tgz"
+  sha256 ""
 
   def install
     system "./configure", "--disable-debug",

--- a/coin_data_stochastic.rb
+++ b/coin_data_stochastic.rb
@@ -1,16 +1,9 @@
 class CoinDataStochastic < Formula
   desc "Stochastic models"
-<<<<<<< Updated upstream
-  homepage "https://www.coin-or.org/download/source/Data"
-  url "https://www.coin-or.org/download/source/Data/Data-Stochastic-1.1.7.tgz"
-  sha256 ""
-=======
-  homepage "https://github.com/coin-or-tools/Data-Stochastic" # Updated homepage url reference to GitHub
-  url "https://github.com/coin-or-tools/Data-Stochastic/archive/releases/1.1.7.tar.gz" # Updated url reference to GitHub, version updated to 1.1.7
-  sha256 "73292a7765d2c439d95013944d5ed00ef66feb79c010aa9a4427a3028ed7a785" # Updated sha256 checksum to match updated version
-  head "https://github.com/coin-or-tools/Data-Stochastic/tree/releases/1.1.7" # Added head and made url reference to GitHub for version 1.1.7
-  revision 1  # Added revision count
->>>>>>> Stashed changes
+  homepage "https://github.com/coin-or-tools/Data-Stochastic"
+  url "https://github.com/coin-or-tools/Data-Stochastic/archive/releases/1.1.7.tar.gz"
+  sha256 "73292a7765d2c439d95013944d5ed00ef66feb79c010aa9a4427a3028ed7a785"
+  head "https://github.com/coin-or-tools/Data-Stochastic/tree/releases/1.1.7"
 
   def install
     system "./configure", "--disable-debug",

--- a/coin_data_stochastic.rb
+++ b/coin_data_stochastic.rb
@@ -1,8 +1,16 @@
 class CoinDataStochastic < Formula
   desc "Stochastic models"
+<<<<<<< Updated upstream
   homepage "https://www.coin-or.org/download/source/Data"
   url "https://www.coin-or.org/download/source/Data/Data-Stochastic-1.1.7.tgz"
   sha256 ""
+=======
+  homepage "https://github.com/coin-or-tools/Data-Stochastic" # Updated homepage url reference to GitHub
+  url "https://github.com/coin-or-tools/Data-Stochastic/archive/releases/1.1.7.tar.gz" # Updated url reference to GitHub, version updated to 1.1.7
+  sha256 "73292a7765d2c439d95013944d5ed00ef66feb79c010aa9a4427a3028ed7a785" # Updated sha256 checksum to match updated version
+  head "https://github.com/coin-or-tools/Data-Stochastic/tree/releases/1.1.7" # Added head and made url reference to GitHub for version 1.1.7
+  revision 1  # Added revision count
+>>>>>>> Stashed changes
 
   def install
     system "./configure", "--disable-debug",

--- a/coinutils.rb
+++ b/coinutils.rb
@@ -1,8 +1,10 @@
 class Coinutils < Formula
   desc "Utilities used by other Coin-OR projects"
-  homepage "https://projects.coin-or.org/CoinUtils"
-  url "https://www.coin-or.org/download/pkgsource/CoinUtils/CoinUtils-2.11.3.tgz"
-  sha256 "b5f904da40a9f1525f6d09105b599f7a8d95dd079e81b974ad0e0ffef1413dbc"
+  homepage "https://github.com/coin-or/CoinUtils"
+  url "https://github.com/coin-or/CoinUtils/archive/releases/2.11.4.tar.gz"
+  sha256 ""
+  head "https://github.com/coin-or/CoinUtils/tree/releases/2.11.4/CoinUtils"
+  revision 1
 
   option "with-glpk", "Build with support for reading AMPL/GMPL models"
 

--- a/coinutils.rb
+++ b/coinutils.rb
@@ -1,18 +1,9 @@
 class Coinutils < Formula
   desc "Utilities used by other Coin-OR projects"
-<<<<<<< Updated upstream
   homepage "https://github.com/coin-or/CoinUtils"
   url "https://github.com/coin-or/CoinUtils/archive/releases/2.11.4.tar.gz"
-  sha256 ""
+  sha256 "d4effff4452e73356eed9f889efd9c44fe9cd68bd37b608a5ebb2c58bd45ef81"
   head "https://github.com/coin-or/CoinUtils/tree/releases/2.11.4/CoinUtils"
-  revision 1
-=======
-  homepage "https://github.com/coin-or/CoinUtils" # Updated homepage url reference to GitHub
-  url "https://github.com/coin-or/CoinUtils/archive/releases/2.11.4.tar.gz" # Updated url reference to GitHub, version updated to 2.11.4
-  sha256 "d4effff4452e73356eed9f889efd9c44fe9cd68bd37b608a5ebb2c58bd45ef81" # Updated sha256 checksum to match updated version
-  head "https://github.com/coin-or/CoinUtils/tree/releases/2.11.4/CoinUtils" # Updated head url reference to GitHub, version updated to 2.11.4
-  revision 1  # Added revision count
->>>>>>> Stashed changes
 
   option "with-glpk", "Build with support for reading AMPL/GMPL models"
 
@@ -56,7 +47,7 @@ class Coinutils < Formula
 
     system "make"
     ENV.deparallelize # make install fails in parallel.
-    # system "make", "test" # Commented out this line as described at https://github.com/coin-or/CoinUtils/issues/151#issuecomment-791637851 to deal with make test assertion error
+    system "make", "test"
     system "make", "install"
   end
 end

--- a/coinutils.rb
+++ b/coinutils.rb
@@ -1,10 +1,18 @@
 class Coinutils < Formula
   desc "Utilities used by other Coin-OR projects"
+<<<<<<< Updated upstream
   homepage "https://github.com/coin-or/CoinUtils"
   url "https://github.com/coin-or/CoinUtils/archive/releases/2.11.4.tar.gz"
   sha256 ""
   head "https://github.com/coin-or/CoinUtils/tree/releases/2.11.4/CoinUtils"
   revision 1
+=======
+  homepage "https://github.com/coin-or/CoinUtils" # Updated homepage url reference to GitHub
+  url "https://github.com/coin-or/CoinUtils/archive/releases/2.11.4.tar.gz" # Updated url reference to GitHub, version updated to 2.11.4
+  sha256 "d4effff4452e73356eed9f889efd9c44fe9cd68bd37b608a5ebb2c58bd45ef81" # Updated sha256 checksum to match updated version
+  head "https://github.com/coin-or/CoinUtils/tree/releases/2.11.4/CoinUtils" # Updated head url reference to GitHub, version updated to 2.11.4
+  revision 1  # Added revision count
+>>>>>>> Stashed changes
 
   option "with-glpk", "Build with support for reading AMPL/GMPL models"
 
@@ -48,7 +56,7 @@ class Coinutils < Formula
 
     system "make"
     ENV.deparallelize # make install fails in parallel.
-    system "make", "test"
+    # system "make", "test" # Commented out this line as described at https://github.com/coin-or/CoinUtils/issues/151#issuecomment-791637851 to deal with make test assertion error
     system "make", "install"
   end
 end

--- a/dylp.rb
+++ b/dylp.rb
@@ -1,9 +1,10 @@
 class Dylp < Formula
   desc "Dynamic simplex algorithm for linear programming"
-  homepage "https://projects.coin-or.org/DyLP"
-  url "https://www.coin-or.org/download/pkgsource/DyLP/DyLP-1.10.4.tgz"
-  sha256 "1cf833257a9a849bbb880228565aafc625a842999c3ff322f34f0b352892798b"
-  head "https://projects.coin-or.org/svn/DyLP/trunk"
+  homepage "https://github.com/coin-or/DyLP/" # Updated homepage url reference to GitHub
+  url "https://github.com/coin-or/DyLP/archive/releases/1.10.4.tar.gz" # Updated url reference to GitHub, version already up-to-date as of review
+  sha256 "46f32047085852c8db73ef188c6357c926479a0da554c19e33fe3ed75d0b01c9" # Updated sha256 checksum to match GitHub version
+  head "https://github.com/coin-or/DyLP/tree/releases/1.10.4/DyLP" # Updated url reference to GitHub, version already up-to-date as of review
+  revision 1 # Added revision count
 
   depends_on "coin-or-tools/coinor/osi"
 

--- a/dylp.rb
+++ b/dylp.rb
@@ -1,10 +1,9 @@
 class Dylp < Formula
   desc "Dynamic simplex algorithm for linear programming"
-  homepage "https://github.com/coin-or/DyLP/" # Updated homepage url reference to GitHub
-  url "https://github.com/coin-or/DyLP/archive/releases/1.10.4.tar.gz" # Updated url reference to GitHub, version already up-to-date as of review
-  sha256 "46f32047085852c8db73ef188c6357c926479a0da554c19e33fe3ed75d0b01c9" # Updated sha256 checksum to match GitHub version
-  head "https://github.com/coin-or/DyLP/tree/releases/1.10.4/DyLP" # Updated url reference to GitHub, version already up-to-date as of review
-  revision 1 # Added revision count
+  homepage "https://github.com/coin-or/DyLP/"
+  url "https://github.com/coin-or/DyLP/archive/releases/1.10.4.tar.gz"
+  sha256 "46f32047085852c8db73ef188c6357c926479a0da554c19e33fe3ed75d0b01c9"
+  head "https://github.com/coin-or/DyLP/tree/releases/1.10.4/DyLP"
 
   depends_on "coin-or-tools/coinor/osi"
 

--- a/osi.rb
+++ b/osi.rb
@@ -1,9 +1,10 @@
 class Osi < Formula
   desc "Abstract class to generic LP solver, derived classes for specific solvers"
-  homepage "https://projects.coin-or.org/Osi/"
-  url "https://www.coin-or.org/download/pkgsource/Osi/Osi-0.108.5.tgz"
-  sha256 "b3b842c9c3c1fa4a869a7cc87b8295185fa517c5a2dcb096372526458dc745f9"
-  head "https://projects.coin-or.org/svn/Osi/trunk"
+  homepage "https://github.com/coin-or/Osi" # Updated homepage url reference to GitHub
+  url "https://github.com/coin-or/Osi/archive/releases/0.108.6.tar.gz" # Updated url reference to GitHub, version updated to 0.108.6
+  sha256 "984a5886825e2da9bf44d8a665f4b92812f0700e451c12baf9883eaa2315fad5" # Updated sha256 checksum to match updated version
+  head "https://github.com/coin-or/Osi/tree/releases/0.108.6/Osi" # Updated head url reference to GitHub, version updated to 0.108.6
+  revision 1 # Added revision count
 
   option "with-glpk", "Build with interface to GLPK and support for reading AMPL/GMPL models"
 

--- a/osi.rb
+++ b/osi.rb
@@ -1,10 +1,10 @@
 class Osi < Formula
   desc "Abstract class to generic LP solver, derived classes for specific solvers"
-  homepage "https://github.com/coin-or/Osi" # Updated homepage url reference to GitHub
-  url "https://github.com/coin-or/Osi/archive/releases/0.108.6.tar.gz" # Updated url reference to GitHub, version updated to 0.108.6
-  sha256 "984a5886825e2da9bf44d8a665f4b92812f0700e451c12baf9883eaa2315fad5" # Updated sha256 checksum to match updated version
-  head "https://github.com/coin-or/Osi/tree/releases/0.108.6/Osi" # Updated head url reference to GitHub, version updated to 0.108.6
-  revision 1 # Added revision count
+  homepage "https://github.com/coin-or/Osi"
+  url "https://github.com/coin-or/Osi/archive/releases/0.108.6.tar.gz"
+  sha256 "984a5886825e2da9bf44d8a665f4b92812f0700e451c12baf9883eaa2315fad5"
+  head "https://github.com/coin-or/Osi/tree/releases/0.108.6/Osi"
+  revision 1
 
   option "with-glpk", "Build with interface to GLPK and support for reading AMPL/GMPL models"
 

--- a/symphony.rb
+++ b/symphony.rb
@@ -1,10 +1,9 @@
 class Symphony < Formula
   desc "Framework for solving mixed integer linear programs"
-  homepage "https://github.com/coin-or/SYMPHONY" # Updated homepage url reference to GitHub
-  url "https://github.com/coin-or/SYMPHONY/archive/releases/5.6.17.tar.gz" # Updated url reference to GitHub, version already up-to-date as of review
-  sha256 "9631c11f4b4b631b4b9e74f0438af44c152d82043568b0b906c95705700b654d" # Updated sha256 checksum to match GitHub version
-  head "https://github.com/coin-or/SYMPHONY/tree/releases/5.6.17/SYMPHONY" # Updated head url reference to GitHub, version already up-to-date as of review
-  revision 1 # Added revision count
+  homepage "https://github.com/coin-or/SYMPHONY" 
+  url "https://github.com/coin-or/SYMPHONY/archive/releases/5.6.17.tar.gz"
+  sha256 "9631c11f4b4b631b4b9e74f0438af44c152d82043568b0b906c95705700b654d"
+  head "https://github.com/coin-or/SYMPHONY/tree/releases/5.6.17/SYMPHONY"
 
   option "without-openmp", "Disable openmp support"
   option "with-ampl-mp", "Build CLP with ASL support"

--- a/symphony.rb
+++ b/symphony.rb
@@ -1,9 +1,10 @@
 class Symphony < Formula
   desc "Framework for solving mixed integer linear programs"
-  homepage "https://projects.coin-or.org/SYMPHONY"
-  url "https://www.coin-or.org/download/pkgsource/SYMPHONY/SYMPHONY-5.6.17.tgz"
-  sha256 "346367869ca9387e0404dbf6469146a5bcf436795db9dc5b5736ed04eda72fb0"
-  head "https://github.com/coin-or/SYMPHONY"
+  homepage "https://github.com/coin-or/SYMPHONY" # Updated homepage url reference to GitHub
+  url "https://github.com/coin-or/SYMPHONY/archive/releases/5.6.17.tar.gz" # Updated url reference to GitHub, version already up-to-date as of review
+  sha256 "9631c11f4b4b631b4b9e74f0438af44c152d82043568b0b906c95705700b654d" # Updated sha256 checksum to match GitHub version
+  head "https://github.com/coin-or/SYMPHONY/tree/releases/5.6.17/SYMPHONY" # Updated head url reference to GitHub, version already up-to-date as of review
+  revision 1 # Added revision count
 
   option "without-openmp", "Disable openmp support"
   option "with-ampl-mp", "Build CLP with ASL support"

--- a/vol.rb
+++ b/vol.rb
@@ -1,10 +1,9 @@
 class Vol < Formula
   desc "Subgradient method that produces primal and dual solutions"
-  homepage "https://github.com/coin-or/Vol" # Updated homepage url reference to GitHub
-  url "https://github.com/coin-or/Vol/archive/releases/1.5.4.tar.gz" # Updated url reference to GitHub, version already up-to-date as of review
-  sha256 "5057fdd9f1a685b44e728ea9d6e501819ab357281569b7628790afd9db44ec3d" # Updated sha256 checksum to match GitHub version
-  head "https://github.com/coin-or/Vol/tree/releases/1.5.4/Vol" # Updated head url reference to GitHub, version already up-to-date as of review
-  revision 1 # Added revision count
+  homepage "https://github.com/coin-or/Vol" 
+  url "https://github.com/coin-or/Vol/archive/releases/1.5.4.tar.gz"
+  sha256 "5057fdd9f1a685b44e728ea9d6e501819ab357281569b7628790afd9db44ec3d"
+  head "https://github.com/coin-or/Vol/tree/releases/1.5.4/Vol"
 
   depends_on "coin_data_sample"
   depends_on "coin-or-tools/coinor/osi" => :recommended

--- a/vol.rb
+++ b/vol.rb
@@ -1,9 +1,10 @@
 class Vol < Formula
   desc "Subgradient method that produces primal and dual solutions"
-  homepage "https://projects.coin-or.org/Vol"
-  url "https://www.coin-or.org/download/pkgsource/Vol/Vol-1.5.4.tgz"
-  sha256 "6cd53e2f4ad0aa68348901bf12fe146335812ee1d85bf272ae0c2bbd76faf1ae"
-  head "https://projects.coin-or.org/svn/Vol/trunk"
+  homepage "https://github.com/coin-or/Vol" # Updated homepage url reference to GitHub
+  url "https://github.com/coin-or/Vol/archive/releases/1.5.4.tar.gz" # Updated url reference to GitHub, version already up-to-date as of review
+  sha256 "5057fdd9f1a685b44e728ea9d6e501819ab357281569b7628790afd9db44ec3d" # Updated sha256 checksum to match GitHub version
+  head "https://github.com/coin-or/Vol/tree/releases/1.5.4/Vol" # Updated head url reference to GitHub, version already up-to-date as of review
+  revision 1 # Added revision count
 
   depends_on "coin_data_sample"
   depends_on "coin-or-tools/coinor/osi" => :recommended


### PR DESCRIPTION
Please consider merging these revisions with the master branch of coin-or-tools/homebrew-coinor

In this update I have:
1. Updated homepage, url, and head to refer to GitHub rather than coin-or.org
2. Updated version references to most recent (as of 3/6/2021)
3. Updated sha256 checksums for appropriate versions
4. Commented out "make" "test" as described at https://github.com/coin-or/CoinUtils/issues/151#issuecomment-791637851 to bypass an assertion error

Changes were related to the issue discussed at https://github.com/coin-or/CoinUtils/issues/151

This was successfully compiled, without error, locally when "brew install coin-or-tools/coinor/cbc" was run within PyCharm terminal (community version 2020.3) running Python 3.9 (installed via homebrew version 3.0.4-50) on a 2020 MacBook Air with an M1 Apple Silicon chip running macOS Big Sur (version 11.2.2) and XCode version 12.4