### PR TITLE
Remove deprecated option -noall-load

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Upload bottles as artifact
         if: always() && github.event_name == 'pull_request'
-        uses: actions/upload-artifact@main
+        uses: actions/upload-artifact@v3
         with:
           name: bottles
           path: '*.bottle.*'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,14 +8,23 @@ jobs:
   test-bot:
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-13]
+        os: [ubuntu-22.04, macos-13, macos-14]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@master
 
+      - name: Cache Homebrew Bundler RubyGems
+        id: cache
+        uses: actions/cache@v1
+        with:
+          path: ${{ steps.set-up-homebrew.outputs.gems-path }}
+          key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
+          restore-keys: ${{ runner.os }}-rubygems-
+
       - name: Install Homebrew Bundler RubyGems
+        if: steps.cache.outputs.cache-hit != 'true'
         run: brew install-bundler-gems
 
       - run: brew test-bot --only-cleanup-before
@@ -29,7 +38,7 @@ jobs:
 
       - name: Upload bottles as artifact
         if: always() && github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: bottles
           path: '*.bottle.*'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
   test-bot:
     strategy:
       matrix:
-        os: [macos-13]
+        os: [macos-14]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Homebrew

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
   test-bot:
     strategy:
       matrix:
-        os: [ubuntu-22.04]
+        os: [macos-13]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Homebrew

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,23 +8,14 @@ jobs:
   test-bot:
     strategy:
       matrix:
-        os: [macos-14]
+        os: [ubuntu-22.04, macos-13, macos-14]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@master
 
-      - name: Cache Homebrew Bundler RubyGems
-        id: cache
-        uses: actions/cache@v1
-        with:
-          path: ${{ steps.set-up-homebrew.outputs.gems-path }}
-          key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
-          restore-keys: ${{ runner.os }}-rubygems-
-
       - name: Install Homebrew Bundler RubyGems
-        if: steps.cache.outputs.cache-hit != 'true'
         run: brew install-bundler-gems
 
       - run: brew test-bot --only-cleanup-before
@@ -38,7 +29,7 @@ jobs:
 
       - name: Upload bottles as artifact
         if: always() && github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: bottles
           path: '*.bottle.*'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
   test-bot:
     strategy:
       matrix:
-        os: [ubuntu-22.04]
+        os: [ubuntu-22.04, macos-13]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Homebrew

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
   test-bot:
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-13, macos-14]
+        os: [ubuntu-22.04]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Homebrew

--- a/mumps-seq.rb
+++ b/mumps-seq.rb
@@ -4,6 +4,7 @@ class MumpsSeq < Formula
   url "https://graal.ens-lyon.fr/MUMPS/MUMPS_5.5.1.tar.gz"
   mirror "http://mumps.enseeiht.fr/MUMPS_5.5.1.tar.gz"
   sha256 "1abff294fa47ee4cfd50dfd5c595942b72ebfcedce08142a75a99ab35014fa15"
+  revision 1
 
   bottle do
     root_url "https://github.com/coin-or-tools/homebrew-coinor/releases/download/mumps-seq-5.5.1"

--- a/mumps-seq.rb
+++ b/mumps-seq.rb
@@ -61,7 +61,7 @@ class MumpsSeq < Formula
     # make shared lib
     so = OS.mac? ? "dylib" : "so"
     all_load = OS.mac? ? "-all_load" : "--whole-archive"
-    noall_load = OS.mac? ? "-noall_load" : "--no-whole-archive"
+    noall_load = OS.mac? ? "" : "--no-whole-archive"
     shopts = OS.mac? ? ["-undefined", "dynamic_lookup"] : []
     install_name = ->(libname) { OS.mac? ? ["-Wl,-install_name", "-Wl,#{lib}/#{libname}.#{so}"] : [] }
     cd "lib" do


### PR DESCRIPTION
Per the explanation [here](https://github.com/wazuh/wazuh/pull/21932), this option no longer works in current versions of MacOS and even in older  versions was being ignored with a warning.