### PR TITLE
Update clp formula to use ampl-mp@3.1.0

### DIFF
--- a/ampl-mp@3.1.0.rb
+++ b/ampl-mp@3.1.0.rb
@@ -1,0 +1,44 @@
+class AmplMpAT310 < Formula
+  desc "Open-source library for mathematical programming"
+  homepage "https://ampl.com/"
+  url "https://github.com/ampl/mp/archive/refs/tags/3.1.0.tar.gz"
+  sha256 "587c1a88f4c8f57bef95b58a8586956145417c8039f59b1758365ccc5a309ae9"
+  license "MIT"
+
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
+  depends_on "cmake" => :build
+
+  def install
+    args = %W[
+      -DAMPL_LIBRARY_DIR=#{libexec}/bin
+      -DBUILD_SHARED_LIBS=ON
+      -DBUILD_TESTS=OFF
+      -DCMAKE_INSTALL_RPATH=#{rpath};#{rpath(source: libexec/"bin")}
+    ]
+
+    system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+  end
+
+  test do
+    (testpath/"test.c").write <<~C
+      #include <stdio.h>
+      #include <stdlib.h>
+      #include "mp/ampls-c-api.h"
+
+      int main() {
+          AMPLS_MP_Solver* solver = (AMPLS_MP_Solver*)malloc(sizeof(AMPLS_MP_Solver));
+          free(solver);
+          return 0;
+      }
+    C
+
+    system ENV.cc, "test.c", "-I#{include}/mp", "-L#{lib}", "-lmp", "-o", "test"
+    system "./test"
+  end
+end

--- a/clp.rb
+++ b/clp.rb
@@ -17,7 +17,7 @@ class Clp < Formula
 
   depends_on "pkg-config" => :build
 
-  depends_on "ampl-mp"
+  depends_on "ampl-mp@3.1.0"
   depends_on "coin-or-tools/coinor/coinutils"
   depends_on "coin-or-tools/coinor/glpk@448"
   depends_on "coin-or-tools/coinor/mumps-seq"
@@ -49,8 +49,8 @@ class Clp < Formula
     args << "--with-glpk-lib=-L#{Formula["coin-or-tools/coinor/glpk@448"].opt_lib} -lglpk"
     args << "--with-glpk-incdir=#{Formula["coin-or-tools/coinor/glpk@448"].opt_include}"
 
-    args << "--with-asl-incdir=#{Formula["ampl-mp"].opt_include}/asl"
-    args << "--with-asl-lib=-L#{Formula["ampl-mp"].opt_lib} -lasl"
+    args << "--with-asl-incdir=#{Formula["ampl-mp@3.1.0"].opt_include}/asl"
+    args << "--with-asl-lib=-L#{Formula["ampl-mp@3.1.0"].opt_lib} -lasl"
 
     mumps_libs = %w[-ldmumps -lmumps_common -lpord -lmpiseq]
     mumps_libcmd = "-L#{Formula["coin-or-tools/coinor/mumps-seq"].opt_lib} " + mumps_libs.join(" ")


### PR DESCRIPTION
From https://github.com/coin-or-tools/homebrew-coinor/issues/101#issuecomment-2625196693 

This PR pins ampl-mp to version `3.1.0`