### PR TITLE
Update clp formula to use ampl-mp@3.1.0 #102

### DIFF
--- a/ampl-mp@3.1.0.rb
+++ b/ampl-mp@3.1.0.rb
@@ -11,7 +11,10 @@ class AmplMpAT310 < Formula
   end
 
   depends_on "cmake" => :build
+  depends_on "gcc@9"
 
+  patch :DATA
+  
   def install
     args = %W[
       -DAMPL_LIBRARY_DIR=#{libexec}/bin
@@ -37,8 +40,42 @@ class AmplMpAT310 < Formula
           return 0;
       }
     C
-
+    
     system ENV.cc, "test.c", "-I#{include}/mp", "-L#{lib}", "-lmp", "-o", "test"
     system "./test"
   end
 end
+
+__END__
+--- a/include/mp/format.h
++++ b/include/mp/format.h
+@@ -1747,21 +1747,21 @@
+     typedef typename BasicWriter<Char>::CharPtr CharPtr;
+     Char fill = internal::CharTraits<Char>::cast(spec_.fill());
+     CharPtr out = CharPtr();
+-    const unsigned CHAR_WIDTH = 1;
+-    if (spec_.width_ > CHAR_WIDTH) {
++    const unsigned C_WIDTH = 1;
++    if (spec_.width_ > C_WIDTH) {
+       out = writer_.grow_buffer(spec_.width_);
+       if (spec_.align_ == ALIGN_RIGHT) {
+-        std::uninitialized_fill_n(out, spec_.width_ - CHAR_WIDTH, fill);
+-        out += spec_.width_ - CHAR_WIDTH;
++        std::uninitialized_fill_n(out, spec_.width_ - C_WIDTH, fill);
++        out += spec_.width_ - C_WIDTH;
+       } else if (spec_.align_ == ALIGN_CENTER) {
+         out = writer_.fill_padding(out, spec_.width_,
+-                                   internal::check(CHAR_WIDTH), fill);
++                                   internal::check(C_WIDTH), fill);
+       } else {
+-        std::uninitialized_fill_n(out + CHAR_WIDTH,
+-                                  spec_.width_ - CHAR_WIDTH, fill);
++        std::uninitialized_fill_n(out + C_WIDTH,
++                                  spec_.width_ - C_WIDTH, fill);
+       }
+     } else {
+-      out = writer_.grow_buffer(CHAR_WIDTH);
++      out = writer_.grow_buffer(C_WIDTH);
+     }
+     *out = internal::CharTraits<Char>::cast(value);
+   }

--- a/ampl-mp@3.1.0.rb
+++ b/ampl-mp@3.1.0.rb
@@ -11,9 +11,32 @@ class AmplMpAT310 < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "gcc@9"
 
-  patch :DATA
+  resource "miniampl" do
+    url "https://github.com/dpo/miniampl/archive/refs/tags/v1.0.tar.gz"
+    sha256 "b836dbf1208426f4bd93d6d79d632c6f5619054279ac33453825e036a915c675"
+  end
+
+  # Removes Google Benchmark - as already done so upstream
+  # All it did was conflict with the google-benchmark formula
+  patch do
+    url "https://github.com/ampl/mp/commit/96e332bb8cb7ba925e3ac947d6df515496027eed.patch?full_index=1"
+    sha256 "1a4ef4cd1f4e8b959c20518f8f00994ef577e74e05824b2d1b241b1c3c1f84eb"
+  end
+
+  # Install missing header files, remove in > 3.1.0
+  # https://github.com/ampl/mp/issues/110
+  patch do
+    url "https://github.com/ampl/mp/commit/8183be3e486d38d281e0c5a02a1ea4239695035e.patch?full_index=1"
+    sha256 "6b37201f1d0d6dba591e7e1b81fb16d2694d118605c92c422dcdaaedb463c367"
+  end
+  # Backport fmt header update. Remove in the next release
+  # https://github.com/ampl/mp/issues/108
+
+  patch do
+    url "https://github.com/ampl/mp/commit/1f39801af085656e4bf72250356a3a70d5d98e73.patch?full_index=1"
+    sha256 "b0e0185f24caba54cb38b65a638ebda6eb4db3e8c74d71ca79f072b8337e8e2c"
+  end
 
   def install
     args = %W[
@@ -29,53 +52,12 @@ class AmplMpAT310 < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~C
-      #include <stdio.h>
-      #include <stdlib.h>
-      #include "mp/ampls-c-api.h"
-
-      int main() {
-          AMPLS_MP_Solver* solver = (AMPLS_MP_Solver*)malloc(sizeof(AMPLS_MP_Solver));
-          free(solver);
-          return 0;
-      }
-    C
-
-    system ENV.cc, "test.c", "-I#{include}/mp", "-L#{lib}", "-lmp", "-o", "test"
-    system "./test"
+    resource("miniampl").stage do
+      testpath.install "src/miniampl.c", Dir["examples/wb.*"]
+    end
+    system ENV.cc, "miniampl.c", "-std=c99", "-I#{include}/asl", "-L#{lib}", "-lasl", "-lmp"
+    output = shell_output("./a.out wb showname=1 showgrad=1")
+    assert_match "Objective name: objective", output
   end
 end
 
-__END__
---- a/include/mp/format.h
-+++ b/include/mp/format.h
-@@ -1747,21 +1747,21 @@
-     typedef typename BasicWriter<Char>::CharPtr CharPtr;
-     Char fill = internal::CharTraits<Char>::cast(spec_.fill());
-     CharPtr out = CharPtr();
--    const unsigned CHAR_WIDTH = 1;
--    if (spec_.width_ > CHAR_WIDTH) {
-+    const unsigned C_WIDTH = 1;
-+    if (spec_.width_ > C_WIDTH) {
-       out = writer_.grow_buffer(spec_.width_);
-       if (spec_.align_ == ALIGN_RIGHT) {
--        std::uninitialized_fill_n(out, spec_.width_ - CHAR_WIDTH, fill);
--        out += spec_.width_ - CHAR_WIDTH;
-+        std::uninitialized_fill_n(out, spec_.width_ - C_WIDTH, fill);
-+        out += spec_.width_ - C_WIDTH;
-       } else if (spec_.align_ == ALIGN_CENTER) {
-         out = writer_.fill_padding(out, spec_.width_,
--                                   internal::check(CHAR_WIDTH), fill);
-+                                   internal::check(C_WIDTH), fill);
-       } else {
--        std::uninitialized_fill_n(out + CHAR_WIDTH,
--                                  spec_.width_ - CHAR_WIDTH, fill);
-+        std::uninitialized_fill_n(out + C_WIDTH,
-+                                  spec_.width_ - C_WIDTH, fill);
-       }
-     } else {
--      out = writer_.grow_buffer(CHAR_WIDTH);
-+      out = writer_.grow_buffer(C_WIDTH);
-     }
-     *out = internal::CharTraits<Char>::cast(value);
-   }

--- a/ampl-mp@3.1.0.rb
+++ b/ampl-mp@3.1.0.rb
@@ -60,4 +60,3 @@ class AmplMpAT310 < Formula
     assert_match "Objective name: objective", output
   end
 end
-

--- a/ampl-mp@3.1.0.rb
+++ b/ampl-mp@3.1.0.rb
@@ -5,11 +5,6 @@ class AmplMpAT310 < Formula
   sha256 "587c1a88f4c8f57bef95b58a8586956145417c8039f59b1758365ccc5a309ae9"
   license "MIT"
 
-  livecheck do
-    url :stable
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
-  end
-
   depends_on "cmake" => :build
 
   resource "miniampl" do

--- a/ampl-mp@3.1.0.rb
+++ b/ampl-mp@3.1.0.rb
@@ -44,6 +44,7 @@ class AmplMpAT310 < Formula
       -DBUILD_SHARED_LIBS=ON
       -DBUILD_TESTS=OFF
       -DCMAKE_INSTALL_RPATH=#{rpath};#{rpath(source: libexec/"bin")}
+      -DCMAKE_DISABLE_FIND_PACKAGE_ODBC=TRUE
     ]
 
     system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args

--- a/ampl-mp@3.1.0.rb
+++ b/ampl-mp@3.1.0.rb
@@ -1,0 +1,44 @@
+class AmplMpAT310 < Formula
+  desc "Open-source library for mathematical programming"
+  homepage "https://ampl.com/"
+  url "https://github.com/ampl/mp/archive/refs/tags/3.1.0.tar.gz"
+  sha256 "587c1a88f4c8f57bef95b58a8586956145417c8039f59b1758365ccc5a309ae9"
+  license "MIT"
+
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
+  depends_on "cmake" => :build
+
+  def install
+    args = %W[
+      -DAMPL_LIBRARY_DIR=#{libexec}/bin
+      -DBUILD_SHARED_LIBS=ON
+      -DBUILD_TESTS=OFF
+      -DCMAKE_INSTALL_RPATH=#{rpath};#{rpath(source: libexec/"bin")}
+    ]
+
+    system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+  end
+
+  test do
+    (testpath/"test.c").write <<~C
+      #include <stdio.h>
+      #include <stdlib.h>
+      #include "mp/ampls-c-api.h"
+
+      int main() {
+          AMPLS_MP_Solver* solver = (AMPLS_MP_Solver*)malloc(sizeof(AMPLS_MP_Solver));
+          free(solver);
+          return 0;
+      }
+    C
+
+    system ENV.cc, "test.c", "-I#{include}/mp", "-L#{lib}", "-lmp", "-o", "test"
+    system "./test"
+  end
+end

--- a/ampl-mp@3.1.0.rb
+++ b/ampl-mp@3.1.0.rb
@@ -14,7 +14,7 @@ class AmplMpAT310 < Formula
   depends_on "gcc@9"
 
   patch :DATA
-  
+
   def install
     args = %W[
       -DAMPL_LIBRARY_DIR=#{libexec}/bin
@@ -40,7 +40,7 @@ class AmplMpAT310 < Formula
           return 0;
       }
     C
-    
+
     system ENV.cc, "test.c", "-I#{include}/mp", "-L#{lib}", "-lmp", "-o", "test"
     system "./test"
   end

--- a/cbc.rb
+++ b/cbc.rb
@@ -18,7 +18,7 @@ class Cbc < Formula
 
   depends_on "pkg-config" => :build
 
-  depends_on "ampl-mp"
+  depends_on "ampl-mp@3.1.0"
   depends_on "coin-or-tools/coinor/cgl"
   depends_on "coin-or-tools/coinor/clp"
   depends_on "coin-or-tools/coinor/glpk@448"

--- a/cbc.rb
+++ b/cbc.rb
@@ -28,6 +28,7 @@ class Cbc < Formula
   depends_on "coin-or-tools/coinor/osi"
   depends_on "gcc"
   depends_on "zlib"
+  depends_on "openblas"
 
   def install
     args = ["--disable-debug",

--- a/cbc.rb
+++ b/cbc.rb
@@ -19,6 +19,11 @@ class Cbc < Formula
   depends_on "pkg-config" => :build
 
   depends_on "ampl-mp@3.1.0"
+  depends_on "openblas"
+  depends_on "bzip2"
+  depends_on "zlib"
+  depends_on "coin-or-tools/coinor/coinutils"
+  depends_on "coin-or-tools/coinor/osi"
   depends_on "coin-or-tools/coinor/cgl"
   depends_on "coin-or-tools/coinor/clp"
   depends_on "coin-or-tools/coinor/glpk@448"

--- a/cbc.rb
+++ b/cbc.rb
@@ -3,7 +3,7 @@ class Cbc < Formula
   homepage "https://github.com/coin-or/Cbc"
   url "https://github.com/coin-or/Cbc/archive/refs/tags/releases/2.10.7.tar.gz"
   sha256 "5aa5490e2bc39c3c03f3636c9bca459cb3f8f365e0280fd0c4759ce3119e5b19"
-  revision 1
+  revision 2
 
   head "https://github.com/coin-or/Cbc.git"
 

--- a/cbc.rb
+++ b/cbc.rb
@@ -39,8 +39,8 @@ class Cbc < Formula
     args << "--with-glpk-lib=-L#{Formula["coin-or-tools/coinor/glpk@448"].opt_lib} -lglpk"
     args << "--with-glpk-incdir=#{Formula["coin-or-tools/coinor/glpk@448"].opt_include}"
 
-    args << "--with-asl-incdir=#{Formula["ampl-mp"].opt_include}/asl"
-    args << "--with-asl-lib=-L#{Formula["ampl-mp"].opt_lib} -lasl"
+    args << "--with-asl-incdir=#{Formula["ampl-mp@3.1.0"].opt_include}/asl"
+    args << "--with-asl-lib=-L#{Formula["ampl-mp@3.1.0"].opt_lib} -lasl"
 
     system "./configure", *args
 

--- a/cbc.rb
+++ b/cbc.rb
@@ -19,16 +19,15 @@ class Cbc < Formula
   depends_on "pkg-config" => :build
 
   depends_on "ampl-mp@3.1.0"
-  depends_on "openblas"
   depends_on "bzip2"
-  depends_on "zlib"
-  depends_on "coin-or-tools/coinor/coinutils"
-  depends_on "coin-or-tools/coinor/osi"
   depends_on "coin-or-tools/coinor/cgl"
   depends_on "coin-or-tools/coinor/clp"
+  depends_on "coin-or-tools/coinor/coinutils"
   depends_on "coin-or-tools/coinor/glpk@448"
   depends_on "coin-or-tools/coinor/mumps-seq"
+  depends_on "coin-or-tools/coinor/osi"
   depends_on "gcc"
+  depends_on "zlib"
 
   def install
     args = ["--disable-debug",

--- a/cbc.rb
+++ b/cbc.rb
@@ -27,8 +27,8 @@ class Cbc < Formula
   depends_on "coin-or-tools/coinor/mumps-seq"
   depends_on "coin-or-tools/coinor/osi"
   depends_on "gcc"
-  depends_on "zlib"
   depends_on "openblas"
+  depends_on "zlib"
 
   def install
     args = ["--disable-debug",

--- a/cgl.rb
+++ b/cgl.rb
@@ -3,7 +3,7 @@ class Cgl < Formula
   homepage "https://github.com/coin-or/Cgl"
   url "https://github.com/coin-or/Cgl/archive/refs/tags/releases/0.60.5.tar.gz"
   sha256 "5a2e7ca380425b3d7279d0759c625a367d06ec8293698b59f82fae38ae5df64e"
-  revision 1
+  revision 2
 
   head "https://github.com/coin-or/Cgl.git"
 

--- a/cgl.rb
+++ b/cgl.rb
@@ -25,8 +25,8 @@ class Cgl < Formula
   depends_on "coin-or-tools/coinor/glpk@448"
   depends_on "coin-or-tools/coinor/mumps-seq"
   depends_on "coin-or-tools/coinor/osi"
-  depends_on "zlib"
   depends_on "openblas"
+  depends_on "zlib"
 
   def install
     args = ["--disable-debug",

--- a/cgl.rb
+++ b/cgl.rb
@@ -18,7 +18,15 @@ class Cgl < Formula
 
   depends_on "pkg-config" => :build
 
+  depends_on "ampl-mp@3.1.0"
+  depends_on "bzip2"
   depends_on "coin-or-tools/coinor/clp"
+  depends_on "coin-or-tools/coinor/coinutils"
+  depends_on "coin-or-tools/coinor/glpk@448"
+  depends_on "coin-or-tools/coinor/mumps-seq"
+  depends_on "coin-or-tools/coinor/osi"
+  depends_on "zlib"
+  depends_on "openblas"
 
   def install
     args = ["--disable-debug",

--- a/clp.rb
+++ b/clp.rb
@@ -25,8 +25,8 @@ class Clp < Formula
   depends_on "coin-or-tools/coinor/osi"
   depends_on "gcc"
   depends_on "readline"
-  depends_on "zlib"
   depends_on "openblas"
+  depends_on "zlib"
   depends_on "suite-sparse" => :optional
 
   def install

--- a/clp.rb
+++ b/clp.rb
@@ -18,6 +18,9 @@ class Clp < Formula
   depends_on "pkg-config" => :build
 
   depends_on "ampl-mp@3.1.0"
+  depends_on "openblas"
+  depends_on "bzip2"
+  depends_on "zlib"
   depends_on "coin-or-tools/coinor/coinutils"
   depends_on "coin-or-tools/coinor/glpk@448"
   depends_on "coin-or-tools/coinor/mumps-seq"

--- a/clp.rb
+++ b/clp.rb
@@ -3,7 +3,8 @@ class Clp < Formula
   homepage "https://github.com/coin-or/Clp"
   url "https://github.com/coin-or/Clp/archive/refs/tags/releases/1.17.7.tar.gz"
   sha256 "c4c2c0e014220ce8b6294f3be0f3a595a37bef58a14bf9bac406016e9e73b0f5"
-
+  revision 1
+  
   head "https://github.com/coin-or/Clp.git"
 
   bottle do

--- a/clp.rb
+++ b/clp.rb
@@ -17,7 +17,7 @@ class Clp < Formula
 
   depends_on "pkg-config" => :build
 
-  depends_on "ampl-mp"
+  depends_on "ampl-mp@3.1.0"
   depends_on "coin-or-tools/coinor/coinutils"
   depends_on "coin-or-tools/coinor/glpk@448"
   depends_on "coin-or-tools/coinor/mumps-seq"
@@ -49,8 +49,8 @@ class Clp < Formula
     args << "--with-glpk-lib=-L#{Formula["coin-or-tools/coinor/glpk@448"].opt_lib} -lglpk"
     args << "--with-glpk-incdir=#{Formula["coin-or-tools/coinor/glpk@448"].opt_include}"
 
-    args << "--with-asl-incdir=#{Formula["ampl-mp"].opt_include}/asl"
-    args << "--with-asl-lib=-L#{Formula["ampl-mp"].opt_lib} -lasl"
+    args << "--with-asl-incdir=#{Formula["ampl-mp@3.1.0"].opt_include}/asl"
+    args << "--with-asl-lib=-L#{Formula["ampl-mp@3.1.0"].opt_lib} -lasl"
 
     mumps_libs = %w[-ldmumps -lmumps_common -lpord -lmpiseq]
     mumps_libcmd = "-L#{Formula["coin-or-tools/coinor/mumps-seq"].opt_lib} " + mumps_libs.join(" ")

--- a/clp.rb
+++ b/clp.rb
@@ -26,7 +26,7 @@ class Clp < Formula
   depends_on "gcc"
   depends_on "readline"
   depends_on "zlib"
-  depends_on "openblas" => :recommended
+  depends_on "openblas"
   depends_on "suite-sparse" => :optional
 
   def install

--- a/clp.rb
+++ b/clp.rb
@@ -18,15 +18,14 @@ class Clp < Formula
   depends_on "pkg-config" => :build
 
   depends_on "ampl-mp@3.1.0"
-  depends_on "openblas"
   depends_on "bzip2"
-  depends_on "zlib"
   depends_on "coin-or-tools/coinor/coinutils"
   depends_on "coin-or-tools/coinor/glpk@448"
   depends_on "coin-or-tools/coinor/mumps-seq"
   depends_on "coin-or-tools/coinor/osi"
   depends_on "gcc"
   depends_on "readline"
+  depends_on "zlib"
   depends_on "openblas" => :recommended
   depends_on "suite-sparse" => :optional
 

--- a/clp.rb
+++ b/clp.rb
@@ -4,7 +4,7 @@ class Clp < Formula
   url "https://github.com/coin-or/Clp/archive/refs/tags/releases/1.17.7.tar.gz"
   sha256 "c4c2c0e014220ce8b6294f3be0f3a595a37bef58a14bf9bac406016e9e73b0f5"
   revision 1
-  
+
   head "https://github.com/coin-or/Clp.git"
 
   bottle do

--- a/clp.rb
+++ b/clp.rb
@@ -24,8 +24,8 @@ class Clp < Formula
   depends_on "coin-or-tools/coinor/mumps-seq"
   depends_on "coin-or-tools/coinor/osi"
   depends_on "gcc"
-  depends_on "readline"
   depends_on "openblas"
+  depends_on "readline"
   depends_on "zlib"
   depends_on "suite-sparse" => :optional
 

--- a/coinutils.rb
+++ b/coinutils.rb
@@ -22,7 +22,8 @@ class Coinutils < Formula
   depends_on "coin-or-tools/coinor/glpk@448"
   depends_on "doxygen"
   depends_on "gcc"
-  depends_on "openblas" => :recommended
+  depends_on "zlib"
+  depends_on "openblas"
 
   def install
     args = ["--disable-debug",

--- a/coinutils.rb
+++ b/coinutils.rb
@@ -22,8 +22,8 @@ class Coinutils < Formula
   depends_on "coin-or-tools/coinor/glpk@448"
   depends_on "doxygen"
   depends_on "gcc"
-  depends_on "zlib"
   depends_on "openblas"
+  depends_on "zlib"
 
   def install
     args = ["--disable-debug",

--- a/coinutils.rb
+++ b/coinutils.rb
@@ -3,6 +3,7 @@ class Coinutils < Formula
   homepage "https://github.com/coin-or/CoinUtils"
   url "https://github.com/coin-or/CoinUtils/archive/refs/tags/releases/2.11.11.tar.gz"
   sha256 "27da344479f38c82112d738501643dcb229e4ee96a5f87d4f406456bdc1b2cb4"
+  revision 1
 
   head "https://github.com/coin-or/CoinUtils.git"
 

--- a/osi.rb
+++ b/osi.rb
@@ -3,7 +3,8 @@ class Osi < Formula
   homepage "https://github.com/coin-or/Osi"
   url "https://github.com/coin-or/Osi/archive/refs/tags/releases/0.108.10.tar.gz"
   sha256 "614c2b329caf57c00326412266299fdfd93c5691492034fbb46990b5e71cc5a7"
-
+  revision 1
+  
   head "https://github.com/coin-or/Osi.git"
 
   bottle do

--- a/osi.rb
+++ b/osi.rb
@@ -4,7 +4,7 @@ class Osi < Formula
   url "https://github.com/coin-or/Osi/archive/refs/tags/releases/0.108.10.tar.gz"
   sha256 "614c2b329caf57c00326412266299fdfd93c5691492034fbb46990b5e71cc5a7"
   revision 1
-  
+
   head "https://github.com/coin-or/Osi.git"
 
   bottle do

--- a/symphony.rb
+++ b/symphony.rb
@@ -3,7 +3,7 @@ class Symphony < Formula
   homepage "https://github.com/coin-or/SYMPHONY"
   url "https://github.com/coin-or/SYMPHONY/archive/refs/tags/releases/5.6.18.tar.gz"
   sha256 "f566e2986c6b4269a5a128cea13622d3d90b046b7a9151ebd89f27c495f183a0"
-  revision 1
+  revision 2
 
   head "https://github.com/coin-or/SYMPHONY"
 

--- a/symphony.rb
+++ b/symphony.rb
@@ -17,7 +17,9 @@ class Symphony < Formula
 
   depends_on "coin-or-tools/coinor/cgl"
   depends_on "coin-or-tools/coinor/clp"
+  depends_on "coin-or-tools/coinor/coinutils"
   depends_on "coin-or-tools/coinor/glpk@448"
+  depends_on "coin-or-tools/coinor/osi"
   depends_on "gcc"
   depends_on "readline"
 

--- a/symphony.rb
+++ b/symphony.rb
@@ -3,7 +3,6 @@ class Symphony < Formula
   homepage "https://github.com/coin-or/SYMPHONY"
   url "https://github.com/coin-or/SYMPHONY/archive/refs/tags/releases/5.6.18.tar.gz"
   sha256 "f566e2986c6b4269a5a128cea13622d3d90b046b7a9151ebd89f27c495f183a0"
-  revision 1
 
   head "https://github.com/coin-or/SYMPHONY"
 

--- a/symphony.rb
+++ b/symphony.rb
@@ -4,7 +4,7 @@ class Symphony < Formula
   url "https://github.com/coin-or/SYMPHONY/archive/refs/tags/releases/5.6.18.tar.gz"
   sha256 "f566e2986c6b4269a5a128cea13622d3d90b046b7a9151ebd89f27c495f183a0"
   revision 1
-  
+
   head "https://github.com/coin-or/SYMPHONY"
 
   bottle do

--- a/symphony.rb
+++ b/symphony.rb
@@ -3,7 +3,8 @@ class Symphony < Formula
   homepage "https://github.com/coin-or/SYMPHONY"
   url "https://github.com/coin-or/SYMPHONY/archive/refs/tags/releases/5.6.18.tar.gz"
   sha256 "f566e2986c6b4269a5a128cea13622d3d90b046b7a9151ebd89f27c495f183a0"
-
+  revision 1
+  
   head "https://github.com/coin-or/SYMPHONY"
 
   bottle do


### PR DESCRIPTION
(fixed email) 
From https://github.com/coin-or-tools/homebrew-coinor/issues/101#issuecomment-2625196693

This PR pins ampl-mp to version 3.1.0